### PR TITLE
tec: Remove model constructors

### DIFF
--- a/src/models/Session.php
+++ b/src/models/Session.php
@@ -53,15 +53,4 @@ class Session extends \Minz\Model
             'ip' => trim($ip),
         ]);
     }
-
-    /**
-     * Initialize a Session from values.
-     *
-     * @param array $values
-     */
-    public function __construct($values)
-    {
-        parent::__construct(self::PROPERTIES);
-        $this->fromValues($values);
-    }
 }

--- a/src/models/Token.php
+++ b/src/models/Token.php
@@ -44,19 +44,6 @@ class Token extends \Minz\Model
     }
 
     /**
-     * Initialize a User from values (usually from database).
-     *
-     * @param array $values
-     *
-     * @throws \Minz\Error\ModelPropertyError if one of the value is invalid
-     */
-    public function __construct($values)
-    {
-        parent::__construct(self::PROPERTIES);
-        $this->fromValues($values);
-    }
-
-    /**
      * Return whether the token has expired.
      *
      * @return boolean

--- a/src/models/User.php
+++ b/src/models/User.php
@@ -52,8 +52,6 @@ class User extends \Minz\Model
      * @param string $username
      * @param string $email
      * @param string $password
-     *
-     * @throws \Minz\Error\ModelPropertyError if one of the property is invalid
      */
     public static function init($username, $email, $password)
     {
@@ -64,19 +62,6 @@ class User extends \Minz\Model
             'password_hash' => $password ? password_hash($password, PASSWORD_BCRYPT) : '',
             'locale' => \flusio\utils\Locale::DEFAULT_LOCALE,
         ]);
-    }
-
-    /**
-     * Initialize a User from values (usually from database).
-     *
-     * @param array $values
-     *
-     * @throws \Minz\Error\ModelPropertyError if one of the value is invalid
-     */
-    public function __construct($values)
-    {
-        parent::__construct(self::PROPERTIES);
-        $this->fromValues($values);
     }
 
     /**


### PR DESCRIPTION
Changes proposed in this pull request:

It appeared that the models were all created the same way (with a
PROPERTIES and a constructor passing this constant to the parent
constructor). Properties were duplicated in memory which could become a
problem with a lot of models.

I made the PROPERTIES const to be loaded automatically for the classes
inherating from Model and store them in a static variable. It saves few
lines and memory.

Pull request checklist:

- [x] commit messages are clear
- [x] new tests are written (N/A)
- [x] code is manually tested
- [x] documentation is updated (including migration notes) (N/A)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
