### PR TITLE
imp: Rename "read later" in "bookmarked"

### DIFF
--- a/src/Collections.php
+++ b/src/Collections.php
@@ -13,7 +13,7 @@ use Minz\Response;
 class Collections
 {
     /**
-     * Show the bookmarked / read later page
+     * Show the bookmarked page
      *
      * @response 200
      * @response 302 /login?redirect_to=/bookmarked if not connected
@@ -39,7 +39,7 @@ class Collections
         ]);
         if (!$db_bookmarked_collection) {
             return Response::notFound('not_found.phtml', [
-                'error' => _('It looks like you have no “Read Later” collection, you should contact the support.'),
+                'error' => _('It looks like you have no “Bookmarked” collection, you should contact the support.'),
             ]);
         }
 

--- a/src/views/collections/show_bookmarked.phtml
+++ b/src/views/collections/show_bookmarked.phtml
@@ -1,11 +1,11 @@
 <?php
     $this->layout('base.phtml', [
-        'title' => _('Read Later'),
+        'title' => _('Bookmarked'),
     ]);
 ?>
 
 <div class="title">
-    <h1><?= _('Read Later') ?></h1>
+    <h1><?= _('Bookmarked') ?></h1>
 </div>
 
 <form method="post" action="<?= url('add link') ?>">

--- a/src/views/pages/home.phtml
+++ b/src/views/pages/home.phtml
@@ -36,7 +36,7 @@
 <?php if ($current_user): ?>
     <p>
         <a href="<?= url('show bookmarked') ?>">
-            <?= _('Read Later') ?>
+            <?= _('Bookmarked') ?>
         </a>
     </p>
 <?php endif; ?>

--- a/tests/CollectionsTest.php
+++ b/tests/CollectionsTest.php
@@ -47,6 +47,6 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
 
         $response = $this->appRun('get', '/bookmarked');
 
-        $this->assertResponse($response, 404, 'It looks like you have no “Read Later” collection');
+        $this->assertResponse($response, 404, 'It looks like you have no “Bookmarked” collection');
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

Rename "read later" in "bookmarked". The choice was incoherent with the "technical" wording which was already "bookmarked". I think bookmarked is better since it's a bit more generic while still conveying the meaning I have in mind.

Pull request checklist:

- [x] commit messages are clear
- [x] new tests are written N/A
- [x] code is manually tested
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
