### PR TITLE
tec: Set error views only on web Application

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -116,7 +116,10 @@ class Application
         $error = utils\Flash::pop('error');
         $status = utils\Flash::pop('status');
 
-        $response = $this->engine->run($request);
+        $response = $this->engine->run($request, [
+            'not_found_view_pointer' => 'not_found.phtml',
+            'internal_server_error_view_pointer' => 'internal_server_error.phtml',
+        ]);
 
         \Minz\Output\View::declareDefaultVariables([
             'environment' => \Minz\Configuration::$environment,


### PR DESCRIPTION
The errors were handled by the cli Application class as well, but were
returned as HTML and so were unreadable in the console. Also, they were
badly handled because the views are using the "home" route name, which
is not initialized in the cli Application. An error was raised because
this route doesn't exist.

Changes proposed in this pull request:

- Errors views now must be chosen when running the `$engine->run()` method
- The views are only set in the web `Application` class

Pull request checklist:

- [x] commit messages are clear
- [x] new tests are written N/A
- [x] code is manually tested
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
