### PR TITLE
imp: Select locale based on http Accept-Language

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -108,7 +108,8 @@ class Application
         } elseif (isset($_SESSION['locale'])) {
             $locale = $_SESSION['locale'];
         } else {
-            $locale = utils\Locale::DEFAULT_LOCALE;
+            $http_accept_language = $request->header('HTTP_ACCEPT_LANGUAGE');
+            $locale = utils\Locale::best($http_accept_language);
         }
         utils\Locale::setCurrentLocale($locale);
 

--- a/tests/utils/LocaleTest.php
+++ b/tests/utils/LocaleTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace flusio\utils;
+
+class LocaleTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider englishAcceptLanguage
+     */
+    public function testBestWithEnglish($accept_language)
+    {
+        $locale = Locale::best($accept_language);
+
+        $this->assertSame('en_GB', $locale);
+    }
+
+    /**
+     * @dataProvider frenchAcceptLanguage
+     */
+    public function testBestWithFrench($accept_language)
+    {
+        $locale = Locale::best($accept_language);
+
+        $this->assertSame('fr_FR', $locale);
+    }
+
+    public function englishAcceptLanguage()
+    {
+        return [
+            [''],
+            ['en'],
+            ['en-US'],
+            ['en, fr-FR;q=0.8'],
+            ['en-US, en;q=0.8'],
+            ['de_DE'],
+        ];
+    }
+
+    public function frenchAcceptLanguage()
+    {
+        return [
+            ['fr'],
+            ['fr-BE'],
+            ['fr-CA'],
+            ['fr-FR'],
+            ['fr-LU'],
+            ['fr-CH'],
+            ['fr, fr-FR;q=0.8'],
+            ['fr,en;q = 0.8'],
+            ['en;q=0.8, fr'],
+            ['en ; q = 0.8, fr-FR ; q = 0.9'],
+            ['en;q=0.900, fr-fr;q=0.901'],
+            ['fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3'],
+        ];
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:

Add a  `Locale::best()` method to select the most pertinent available locale based on a HTTP Accept-Language header from the browser.

Pull request checklist:

- [x] commit messages are clear
- [x] new tests are written
- [x] code is manually tested
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
