### PR TITLE
fix: Initialize the session from a custom cookie

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -18,8 +18,11 @@ $request_method = strtolower($_SERVER['REQUEST_METHOD']);
 $http_method = $request_method === 'head' ? 'get' : $request_method;
 $http_uri = $_SERVER['REQUEST_URI'];
 $http_parameters = array_merge($_GET, $_POST);
+$headers = array_merge($_SERVER, [
+    'COOKIE' => $_COOKIE,
+]);
 
-$request = new \Minz\Request($http_method, $http_uri, $http_parameters, $_SERVER);
+$request = new \Minz\Request($http_method, $http_uri, $http_parameters, $headers);
 
 // In development mode, all the requests are redirected to this file. However,
 // if the file exists, we want to serve it as-is, which is done by returning
@@ -40,8 +43,13 @@ $application = new \flusio\Application();
 $response = $application->run($request);
 $response->setHeader('Turbolinks-Location', $http_uri);
 
-// Generate the HTTP headers and output
+// Generate the HTTP headers, cookies and output
 http_response_code($response->code());
+
+foreach ($response->cookies() as $cookie) {
+    setcookie($cookie['name'], $cookie['value'], $cookie['options']);
+}
+
 foreach ($response->headers() as $header) {
     header($header);
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -100,6 +100,9 @@ class Application
      */
     public function run($request)
     {
+        if (!utils\CurrentUser::sessionToken()) {
+            utils\CurrentUser::setSessionToken($request->cookie('flusio_session_token'));
+        }
         $current_user = utils\CurrentUser::get();
 
         // Setup current localization

--- a/src/Sessions.php
+++ b/src/Sessions.php
@@ -127,7 +127,11 @@ class Sessions
 
         utils\CurrentUser::setSessionToken($token->token);
 
-        return Response::found($redirect_to);
+        $response = Response::found($redirect_to);
+        $response->setCookie('flusio_session_token', $token->token, [
+            'expires' => $token->expired_at->getTimestamp(),
+        ]);
+        return $response;
     }
 
     /**
@@ -196,6 +200,8 @@ class Sessions
         $session_dao->delete($session->id);
         utils\CurrentUser::reset();
 
-        return Response::redirect('home');
+        $response = Response::redirect('home');
+        $response->removeCookie('flusio_session_token');
+        return $response;
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -6,6 +6,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
 {
     use \tests\LoginHelper;
     use \Minz\Tests\InitializerHelper;
+    use \Minz\Tests\FactoriesHelper;
 
     public function testRunSetsTheDefaultLocale()
     {
@@ -45,5 +46,32 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
         $variables = \Minz\Output\View::defaultVariables();
         $this->assertSame('fr_FR', $variables['current_locale']);
         $this->assertSame('fr_FR', utils\Locale::currentLocale());
+    }
+
+    public function testRunSetsCurrentUserFromCookie()
+    {
+        $expired_at = \Minz\Time::fromNow(30, 'days');
+        $token = $this->create('token', [
+            'expired_at' => $expired_at->format(\Minz\Model::DATETIME_FORMAT),
+        ]);
+        $user_id = $this->create('user');
+        $this->create('session', [
+            'user_id' => $user_id,
+            'token' => $token,
+        ]);
+
+        $user = utils\CurrentUser::get();
+        $this->assertNull($user);
+
+        $request = new \Minz\Request('GET', '/', [], [
+            'COOKIE' => [
+                'flusio_session_token' => $token,
+            ],
+        ]);
+        $application = new Application();
+        $response = $application->run($request);
+
+        $user = utils\CurrentUser::get();
+        $this->assertSame($user_id, $user->id);
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

The sessions were previously dropped due to the PHP session garbage
collector which dropped the value of the current_session_token variable.

The session cookie expiration is set back to 0 (i.e. until the browser is
closed) and a new flusio_session_token cookie is introduced to store the
session token. If the current user is not set yet, we try to initialize
it with this token.

Pull request checklist:

- [x] commit messages are clear
- [x] new tests are written
- [x] code is manually tested
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
