### PR TITLE
fix: Fix title encoding on some websites

### DIFF
--- a/lib/SpiderBits/src/Dom.php
+++ b/lib/SpiderBits/src/Dom.php
@@ -29,7 +29,7 @@ class Dom
     public static function fromText($html_as_string)
     {
         $dom = new \DOMDocument();
-        @$dom->loadHTML($html_as_string);
+        @$dom->loadHTML(mb_convert_encoding($html_as_string, 'HTML-ENTITIES', 'UTF-8'));
         return new self($dom);
     }
 

--- a/tests/lib/SpiderBits/DomTest.php
+++ b/tests/lib/SpiderBits/DomTest.php
@@ -15,6 +15,17 @@ class DomTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Hello World!', $text);
     }
 
+    public function testTextWithMixOfHtmlEntitiesAndUtf8()
+    {
+        $dom = Dom::fromText(<<<HTML
+            <title>Site d&#039;information français</title>
+        HTML);
+
+        $text = $dom->text();
+
+        $this->assertSame("Site d'information français", $text);
+    }
+
     public function testSelect()
     {
         $dom = Dom::fromText(<<<HTML


### PR DESCRIPTION
Changes proposed in this pull request:

- Convert html to HTML-ENTITIES encoding when loading the Dom from text

Pull request checklist:

- [x] commit messages are clear
- [x] new tests are written
- [x] code is manually tested
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
