### PR TITLE
imp: Move link "edit" anchor on show page

### DIFF
--- a/src/views/links/show.phtml
+++ b/src/views/links/show.phtml
@@ -6,12 +6,24 @@
 ?>
 
 <div class="section">
+    <nav class="section__nav">
+        <div class="section__nav-separator"></div>
+
+        <a
+            href="<?= url('edit link', ['id' => $link->id]) ?>"
+            title="<?= _('Settings') ?>"
+            aria-label="<?= _('Settings') ?>"
+        >
+            <i class="icon icon--anchor icon--only icon--cog"></i>
+        </a>
+    </nav>
+
     <div class="section__title section__title--nolowercase">
         <h1><?= $this->protect($link->title) ?></h1>
     </div>
 
     <p class="link__details paragraph--centered">
-        <?= $this->protect($link->host()) ?>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>&nbsp;·&nbsp;<a href="<?= url('edit link', ['id' => $link->id]) ?>"><?= _('edit') ?></a>
+        <?= $this->protect($link->host()) ?>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>
     </p>
 
     <p class="paragraph--centered">


### PR DESCRIPTION
Changes proposed in this pull request:

Move link "edit" anchor on show page

Pull request checklist:

- [x] commit messages are clear
- [x] new tests are written N/A
- [x] code is manually tested
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
