### PR TITLE
imp: Add shortcut to add link to collection placeholder

### DIFF
--- a/src/Links.php
+++ b/src/Links.php
@@ -61,6 +61,7 @@ class Links
      * Show the page to add a link.
      *
      * @request_param string url The URL to prefill the URL input (default is '')
+     * @request_param string[] collection_ids Collection to check (default contains bookmarks id)
      *
      * @response 302 /login?redirect_to=/links/new if not connected
      * @response 200
@@ -84,13 +85,20 @@ class Links
             return Response::redirect('login', ['redirect_to' => $redirect_to]);
         }
 
-        $bookmarks_collection = $user->bookmarks();
         $collections = $user->collections();
         models\Collection::sort($collections, $user->locale);
 
+        $default_collection_id = $request->param('collection');
+        if ($default_collection_id) {
+            $default_collection_ids = [$default_collection_id];
+        } else {
+            $bookmarks_collection = $user->bookmarks();
+            $default_collection_ids = [$bookmarks_collection->id];
+        }
+
         return Response::ok('links/new.phtml', [
             'url' => $default_url,
-            'collection_ids' => [$bookmarks_collection->id],
+            'collection_ids' => $default_collection_ids,
             'collections' => $collections,
         ]);
     }

--- a/src/assets/stylesheets/_anchors.css
+++ b/src/assets/stylesheets/_anchors.css
@@ -27,13 +27,8 @@ a:focus {
 
     text-decoration: none;
 
-    border: 0.1em solid var(--color-text);
+    border: 0.1em solid currentColor;
     border-radius: var(--border-button-radius);
-}
-
-.anchor--action:hover,
-.anchor--action:focus {
-    border-color: inherit;
 }
 
 .anchor--action.icon--anchor {

--- a/src/views/collections/show.phtml
+++ b/src/views/collections/show.phtml
@@ -68,8 +68,14 @@
     </div>
 
     <?php if (!$links): ?>
-        <p class="paragraph--placeholder">
-            <?= _('This collection is empty. The links will appear here once you start adding them.') ?>
-        </p>
+        <div class="paragraph--placeholder">
+            <p>
+                <?= _('This collection is empty. The links will appear here once you start adding them.') ?>
+            </p>
+
+            <a class="anchor--action icon icon--ghost icon--anchor icon--plus-circle" href="<?= url('new link', ['collection' => $collection->id]) ?>">
+                <?= _('Add a link') ?>
+            </a>
+        </div>
     <?php endif; ?>
 </div>

--- a/src/views/collections/show_bookmarks.phtml
+++ b/src/views/collections/show_bookmarks.phtml
@@ -51,8 +51,14 @@
     </div>
 
     <?php if (!$links): ?>
-        <p class="paragraph--placeholder">
-            <?= _('This collection is empty. The links will appear here once you start adding them.') ?>
-        </p>
+        <div class="paragraph--placeholder">
+            <p>
+                <?= _('This collection is empty. The links will appear here once you start adding them.') ?><br />
+            </p>
+
+            <a class="anchor--action icon icon--ghost icon--anchor icon--plus-circle" href="<?= url('new link') ?>">
+                <?= _('Add a link') ?>
+            </a>
+        </div>
     <?php endif; ?>
 </div>

--- a/tests/LinksTest.php
+++ b/tests/LinksTest.php
@@ -93,7 +93,7 @@ class LinksTest extends \PHPUnit\Framework\TestCase
     public function testNewRendersCorrectly()
     {
         $user = $this->login();
-        $this->create('collection', [
+        $bookmarks_collection_id = $this->create('collection', [
             'user_id' => $user->id,
             'type' => 'bookmarks',
         ]);
@@ -102,6 +102,8 @@ class LinksTest extends \PHPUnit\Framework\TestCase
 
         $this->assertResponse($response, 200, 'New link');
         $this->assertPointer($response, 'links/new.phtml');
+        $variables = $response->output()->variables();
+        $this->assertContains($bookmarks_collection_id, $variables['collection_ids']);
     }
 
     public function testNewPrefillsUrl()
@@ -118,6 +120,26 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         ]);
 
         $this->assertResponse($response, 200, $url);
+    }
+
+    public function testNewPrefillsCollection()
+    {
+        $user = $this->login();
+        $this->create('collection', [
+            'user_id' => $user->id,
+            'type' => 'bookmarks',
+        ]);
+        $collection_id = $this->create('collection', [
+            'user_id' => $user->id,
+            'type' => 'collection',
+        ]);
+
+        $response = $this->appRun('get', '/links/new', [
+            'collection' => $collection_id,
+        ]);
+
+        $variables = $response->output()->variables();
+        $this->assertContains($collection_id, $variables['collection_ids']);
     }
 
     public function testNewRedirectsIfNotConnected()


### PR DESCRIPTION
Changes proposed in this pull request:

- Accept a collection id to prefill new link form
- Set `.anchor--action` border color to `currentColor`
- Add shortcut to add link to collection placeholder 

Pull request checklist:

- [x] commit messages are clear
- [x] new tests are written
- [x] code is manually tested
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
