### PR TITLE
fix: Fix title scrapping for Youtube

### DIFF
--- a/lib/SpiderBits/src/DomExtractor.php
+++ b/lib/SpiderBits/src/DomExtractor.php
@@ -19,7 +19,15 @@ class DomExtractor
      */
     public static function title($dom)
     {
-        $title = $dom->select('/html/head/title');
+        // Be strict first
+        $title = $dom->select('/html/head/title[1]');
+        if (!$title) {
+            // Then, if we don't find it for some reasons, be more tolerant.
+            // This is particularly useful for Youtube!
+            // We must be sure to not consider svg title tags though!
+            $title = $dom->select('//title[not(ancestor::svg)][1]');
+        }
+
         if ($title) {
             return $title->text();
         } else {

--- a/tests/lib/SpiderBits/DomExtractorTest.php
+++ b/tests/lib/SpiderBits/DomExtractorTest.php
@@ -19,12 +19,32 @@ class DomExtractorTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('This is title', $title);
     }
 
-    public function testTitleReturnsEmptyStringIfNotInHtmlHead()
+    public function testTitleTakesFirstTitleIfNotInHtmlHead()
     {
         $dom = Dom::fromText(<<<HTML
             <html>
                 <body>
-                    <title>This is title</title>
+                    <title>This is title 1</title>
+                    <title>This is title 2</title>
+                </body>
+            </html>
+        HTML);
+
+        $title = DomExtractor::title($dom);
+
+        $this->assertSame('This is title 1', $title);
+    }
+
+    public function testTitleDoesNotConsiderSvgTitle()
+    {
+        $dom = Dom::fromText(<<<HTML
+            <html>
+                <body>
+                    <svg viewBox="0 0 20 10" xmlns="http://www.w3.org/2000/svg">
+                        <circle cx="5" cy="5" r="4">
+                            <title>I'm a circle</title>
+                        </circle>
+                    </svg>
                 </body>
             </html>
         HTML);


### PR DESCRIPTION
Changes proposed in this pull request:

- Always consider only the first <title> tag
- If title is not found in html/head, look for a title tag in all the HTML (but ignore svg title tags)

Pull request checklist:

- [x] commit messages are clear
- [x] new tests are written
- [x] code is manually tested
- [x] documentation is updated (including migration notes)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
