### PR TITLE
fix: Add a title on "manage" link collections

### DIFF
--- a/src/views/links/show.phtml
+++ b/src/views/links/show.phtml
@@ -52,8 +52,12 @@
             <div class="header__container">
                 <h2 class="subsection__title"><?= _('Collections') ?></h2>
 
-                <a class="icon icon--anchor icon--cog" href="<?= url('link collections', ['id' => $link->id]) ?>">
-                    <span class="sr-only"><?= _('Manage') ?></span>
+                <a
+                    href="<?= url('link collections', ['id' => $link->id]) ?>"
+                    title="<?= _('Manage') ?>"
+                    aria-label="<?= _('Manage') ?>"
+                >
+                    <i class="icon icon--anchor icon--cog"></i>
                 </a>
             </div>
         </header>


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a title on "manage" link collections

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
