### PR TITLE
sec: Forbid access to not owned collections

### DIFF
--- a/src/Links.php
+++ b/src/Links.php
@@ -208,7 +208,7 @@ class Links
             ]);
         }
 
-        if (!$collection_dao->exists($collection_ids)) {
+        if (!$collection_dao->existForUser($user->id, $collection_ids)) {
             return Response::badRequest('links/new.phtml', [
                 'url' => $url,
                 'is_public' => $is_public,

--- a/src/models/dao/Collection.php
+++ b/src/models/dao/Collection.php
@@ -66,4 +66,25 @@ class Collection extends \Minz\DatabaseModel
         $statement->execute([$user_id]);
         return $statement->fetchAll();
     }
+
+    /**
+     * Return if collection ids exist for the given user.
+     *
+     * @param string $user_id
+     * @param string[] $collection_ids
+     *
+     * @return boolean True if all the ids exist
+     */
+    public function existForUser($user_id, $collection_ids)
+    {
+        if (empty($collection_ids)) {
+            return true;
+        }
+
+        $matching_rows = $this->listBy([
+            'id' => $collection_ids,
+            'user_id' => $user_id,
+        ]);
+        return count($matching_rows) === count($collection_ids);
+    }
 }

--- a/src/models/dao/LinksToCollections.php
+++ b/src/models/dao/LinksToCollections.php
@@ -73,4 +73,32 @@ class LinksToCollections extends \Minz\DatabaseModel
         $statement = $this->prepare($sql);
         return $statement->execute($values);
     }
+
+    /**
+     * Attach the collections to the given link and remove old ones if any.
+     *
+     * @param string $link_id
+     * @param string[] $collection_ids
+     *
+     * @return boolean True on success
+     */
+    public function set($link_id, $collection_ids)
+    {
+        $previous_attachments = $this->listBy(['link_id' => $link_id]);
+        $previous_collection_ids = array_column($previous_attachments, 'collection_id');
+        $ids_to_attach = array_diff($collection_ids, $previous_collection_ids);
+        $ids_to_detach = array_diff($previous_collection_ids, $collection_ids);
+
+        $this->beginTransaction();
+
+        if ($ids_to_attach) {
+            $this->attach($link_id, $ids_to_attach);
+        }
+
+        if ($ids_to_detach) {
+            $this->detach($link_id, $ids_to_detach);
+        }
+
+        return $this->commit();
+    }
 }

--- a/src/views/link_collections/index.phtml
+++ b/src/views/link_collections/index.phtml
@@ -36,7 +36,7 @@
                         id="collection-<?= $collection->id ?>"
                         name="collection_ids[]"
                         value="<?= $collection->id ?>"
-                        <?= $collection->attachedToLink ? 'checked' : '' ?>
+                        <?= in_array($collection->id, $collection_ids) ? 'checked' : '' ?>
                     />
                     <label class="label--checkbox" for="collection-<?= $collection->id ?>">
                         <?= $this->protect($collection->name()) ?>

--- a/tests/LinkCollectionsTest.php
+++ b/tests/LinkCollectionsTest.php
@@ -193,6 +193,28 @@ class LinkCollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($link_to_collection_2);
     }
 
+    public function testUpdateFailsIfCollectionIdsContainsNotOwnedId()
+    {
+        $links_to_collections_dao = new models\dao\LinksToCollections();
+        $user = $this->login();
+        $other_user_id = $this->create('user');
+        $link_id = $this->create('link', [
+            'user_id' => $user->id,
+        ]);
+        $collection_id = $this->create('collection', [
+            'user_id' => $other_user_id,
+            'type' => 'collection',
+        ]);
+
+        $response = $this->appRun('post', "/links/{$link_id}/collections", [
+            'csrf' => $user->csrf,
+            'collection_ids' => [$collection_id],
+        ]);
+
+        $this->assertResponse($response, 400, 'One of the associated collection doesn’t exist.');
+        $this->assertSame(0, $links_to_collections_dao->count());
+    }
+
     public function testBookmarkAddsLinkToBookmarks()
     {
         $links_to_collections_dao = new models\dao\LinksToCollections();

--- a/tests/LinksTest.php
+++ b/tests/LinksTest.php
@@ -450,16 +450,19 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(0, $link_dao->count());
     }
 
-    public function testCreateFailsIfCollectionDoesNotExist()
+    public function testCreateFailsIfCollectionIdsContainsNotOwnedId()
     {
         $link_dao = new models\dao\Link();
-
         $user = $this->login();
+        $other_user_id = $this->create('user');
+        $collection_id = $this->create('collection', [
+            'user_id' => $other_user_id,
+        ]);
 
         $response = $this->appRun('post', '/links/new', [
             'csrf' => $user->csrf,
             'url' => $this->fake('url'),
-            'collection_ids' => ['does not exist'],
+            'collection_ids' => [$collection_id],
         ]);
 
         $this->assertResponse($response, 400, 'One of the associated collection doesn’t exist.');


### PR DESCRIPTION
Changes proposed in this pull request:

I didn't test if user had access to the collections when setting links
collections ids. It happened users were able to attach their link to
other users collections. So bad.

- always check collection ids exist for the current user
- improve the rendering of the `link_collections/index.phtml` view (i.e. remove the fake `attachedToLink` property)
- refactor the override of link collections with a `\flusio\models\dao\LinksToCollections::set()` method

While the consequences could be bad, the risk is very low since there are no opened instances of flusio, and collections weren't public in the last version (0.7), so their ids almost impossible to guess. For these reasons, I'll not publish a new version immediatly (I would with a different context).

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
