### PR TITLE
fix: Fix sanitization of titles

### DIFF
--- a/src/views/_layouts/base.phtml
+++ b/src/views/_layouts/base.phtml
@@ -6,7 +6,9 @@
     }
 
     $this->layout($layout_name, [
-        'title' => $title,
+        // The title can be considered as safe since it's already sanitized in
+        // the calling view.
+        'title' => $this->safe('title'),
         'current_action_pointer' => $current_action_pointer,
         'current_locale' => $current_locale,
         'current_tab' => $current_tab,


### PR DESCRIPTION
Changes proposed in this pull request:

The titles were sanitized twice because of the double layout system
(view -> base.phtml -> [not_]connected.phtml). This led to `&` caracter
to be displayed as `&amp;` in the title bar of the browsers.

- Consider `title` as safe in the `base.phtml` layout

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
