### PR TITLE
fix: Fix cards overflow

### DIFF
--- a/src/assets/stylesheets/_cards.css
+++ b/src/assets/stylesheets/_cards.css
@@ -1,5 +1,6 @@
 .cards {
     display: flex;
+    padding: var(--space-smaller);
 
     flex-wrap: wrap;
     justify-content: center;
@@ -13,7 +14,8 @@
     overflow: hidden;
 
     display: flex;
-    margin: var(--space-small);
+    max-width: 100%;
+    margin-bottom: var(--space-medium);
 
     flex-basis: 100%;
     flex-direction: column;
@@ -26,6 +28,9 @@
 
 @media (min-width: 800px) {
     .card {
+        margin-right: var(--space-small);
+        margin-left: var(--space-small);
+
         flex-basis: 30%;
     }
 }
@@ -41,10 +46,13 @@
 }
 
 .card__title {
+    overflow: hidden;
+
     margin-top: 0;
     margin-bottom: 0;
 
     font-size: var(--size-normal);
+    text-overflow: ellipsis;
 }
 
 .card__title.icon {


### PR DESCRIPTION
Changes proposed in this pull request:

There were 2 small issues when cards titles were too long on small
screens:

- the cards were going beyond the screen limits
- the titles were not truncated nicely (i.e. with ellipsis)


Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
