### PR TITLE
imp: Redirect intelligently on link deletion

### DIFF
--- a/src/Links.php
+++ b/src/Links.php
@@ -346,11 +346,12 @@ class Links
      *
      * @request_param string id
      * @request_param string from default is /links/:id
+     * @request_param string redirect_to default is /
      *
      * @response 302 /login?redirect_to=:from if not connected
      * @response 404 if the link doesn’t exist or user hasn't access
      * @response 302 :from if csrf is invalid
-     * @response 302 /
+     * @response 302 :redirect_to on success
      *
      * @param \Minz\Request $request
      *
@@ -361,6 +362,7 @@ class Links
         $user = utils\CurrentUser::get();
         $link_id = $request->param('id');
         $from = $request->param('from', \Minz\Url::for('link', ['id' => $link_id]));
+        $redirect_to = $request->param('redirect_to', \Minz\Url::for('home'));
 
         if (!$user) {
             return Response::redirect('login', ['redirect_to' => $from]);
@@ -380,7 +382,7 @@ class Links
         $link_dao = new models\dao\Link();
         $link_dao->delete($link->id);
 
-        return Response::redirect('home');
+        return Response::found($redirect_to);
     }
 
     /**

--- a/src/assets/javascripts/controllers/back_anchor_controller.js
+++ b/src/assets/javascripts/controllers/back_anchor_controller.js
@@ -3,9 +3,10 @@ import { Controller } from 'stimulus';
 export default class extends Controller {
     connect () {
         const type = this.data.get('type');
+        const replace = this.data.get('replace');
         const backUrl = window.localStorage.getItem('back-' + type);
-        if (backUrl) {
-            this.element.setAttribute('href', backUrl);
+        if (replace && backUrl) {
+            this.element.setAttribute(replace, backUrl);
         }
     }
 };

--- a/src/views/collections/show_public.phtml
+++ b/src/views/collections/show_public.phtml
@@ -13,6 +13,7 @@
             href="<?= url('home') ?>"
             data-controller="back-anchor"
             data-back-anchor-type="collection"
+            data-back-anchor-replace="href"
         >
             <?= _('Back') ?>
         </a>

--- a/src/views/links/new.phtml
+++ b/src/views/links/new.phtml
@@ -108,6 +108,7 @@
                 href="<?= url('news') ?>"
                 data-controller="back-anchor"
                 data-back-anchor-type="link"
+                data-back-anchor-replace="href"
             >
                 <?= _('Cancel and go back') ?>
             </a>

--- a/src/views/links/show.phtml
+++ b/src/views/links/show.phtml
@@ -12,6 +12,7 @@
             href="<?= url('news') ?>"
             data-controller="back-anchor"
             data-back-anchor-type="link"
+            data-back-anchor-replace="href"
         >
             <?= _('Back') ?>
         </a>
@@ -53,6 +54,14 @@
                 >
                     <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
                     <input type="hidden" name="from" value="<?= url('link', ['id' => $link->id]) ?>" />
+                    <input
+                        type="hidden"
+                        name="redirect_to"
+                        value="<?= url('home') ?>"
+                        data-controller="back-anchor"
+                        data-back-anchor-type="link"
+                        data-back-anchor-replace="value"
+                     />
 
                     <button type="submit" class="popup__item popup__item--button icon icon--times">
                         <?= _('Remove the link') ?>

--- a/src/views/links/show_public.phtml
+++ b/src/views/links/show_public.phtml
@@ -12,6 +12,7 @@
             href="<?= url('home') ?>"
             data-controller="back-anchor"
             data-back-anchor-type="link"
+            data-back-anchor-replace="href"
         >
             <?= _('Back') ?>
         </a>

--- a/tests/LinksTest.php
+++ b/tests/LinksTest.php
@@ -690,6 +690,23 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($link_dao->exists($link_id));
     }
 
+    public function testDeleteRedirectsToRedirectToIfGiven()
+    {
+        $user = $this->login();
+        $link_dao = new models\dao\Link();
+        $link_id = $this->create('link', [
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->appRun('post', "/links/{$link_id}/delete", [
+            'csrf' => $user->csrf,
+            'from' => "/links/{$link_id}",
+            'redirect_to' => '/bookmarks',
+        ]);
+
+        $this->assertResponse($response, 302, '/bookmarks');
+    }
+
     public function testDeleteRedirectsIfNotConnected()
     {
         $user_id = $this->create('user', [


### PR DESCRIPTION
Changes proposed in this pull request:

- Accept a `redirect_to` value on link deletion
- Add a hidden input in the deletion form defaulting to `home` URL, but overriding the value with the `back-link` value (`back-anchor` JS controller)
- Modifies the `back-anchor` JS controller to be able to change a different attribute than `href`

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
