### PR TITLE
fix: Don't select link in owned collection for news

### DIFF
--- a/src/models/dao/Link.php
+++ b/src/models/dao/Link.php
@@ -199,6 +199,8 @@ class Link extends \Minz\DatabaseModel
              AND l.is_public = true
              AND c.is_public = true
 
+             AND c.user_id != :user_id
+
              AND l.url NOT IN (
                  SELECT nl.url FROM news_links nl
                  WHERE nl.user_id = :user_id

--- a/tests/services/NewsPickerTest.php
+++ b/tests/services/NewsPickerTest.php
@@ -364,4 +364,40 @@ class NewsPickerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(0, count($db_links));
     }
+
+    public function testPickDoesNotSelectFromTopicsIfCollectionIsOwned()
+    {
+        $news_picker = new NewsPicker($this->user);
+        $topic_id = $this->create('topic');
+        // make the user interested by topic
+        $this->create('user_to_topic', [
+            'user_id' => $this->user->id,
+            'topic_id' => $topic_id,
+        ]);
+        // create a link in a collection associated to topic
+        $link_id = $this->create('link', [
+            'user_id' => $this->user->id,
+            'reading_time' => 10,
+            'is_public' => 1,
+        ]);
+        $collection_id = $this->create('collection', [
+            'user_id' => $this->user->id,
+            'type' => 'collection',
+            'is_public' => 1,
+        ]);
+        $this->create('link_to_collection', [
+            'collection_id' => $collection_id,
+            'link_id' => $link_id,
+        ]);
+        $this->create('collection_to_topic', [
+            'collection_id' => $collection_id,
+            'topic_id' => $topic_id,
+        ]);
+
+        $db_links = $news_picker->pick();
+
+        // because the user owns the collection, we don't get the link
+        // associated to the topic
+        $this->assertSame(0, count($db_links));
+    }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Exlude collections with `user_id` in `models/dao/Link#listFromTopicsForNews`

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
