### PR TITLE
add: Fetch Open Graph images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           with:
               php-version: ${{ matrix.php-versions }}
               coverage: xdebug
-              extensions: intl, gettext, pdo, pdo_pgsql
+              extensions: intl, gettext, gd, pdo, pdo_pgsql
               ini-values: browscap=${{ github.workspace }}/docker/lite_php_browscap.ini
 
         - name: Setup locales

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 !/policies/.keep
 
 /public/dev_assets
+
+/public/media/*
+!/public/media/.keep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog of flusio
 
+## 2020-xx-yy - v0.12
+
+### Migration notes
+
+(optional) flusio now supports Open Graph and Twitter Cards images. For oldest
+links, you can refresh their image by running the following command:
+
+```console
+flusio$ # where NUMBER should be replaced by a positive integer value (default is 10)
+flusio$ php cli --request /links/refresh -pnumber=NUMBER
+```
+
 ## 2020-10-21 - v0.11
 
 ### Breaking changes

--- a/configuration/environment_development.php
+++ b/configuration/environment_development.php
@@ -23,6 +23,7 @@ return [
         'brand' => $dotenv->pop('APP_BRAND', 'flusio'),
         'version' => trim(@file_get_contents($app_path . '/VERSION.txt')),
         'cache_path' => $dotenv->pop('APP_CACHE_PATH', $app_path . '/cache'),
+        'media_path' => $dotenv->pop('APP_MEDIA_PATH', $app_path . '/public/media'),
         'demo' => filter_var($dotenv->pop('APP_DEMO', false), FILTER_VALIDATE_BOOLEAN),
         'registrations_opened' => filter_var($dotenv->pop('APP_OPEN_REGISTRATIONS', true), FILTER_VALIDATE_BOOLEAN),
         'subscriptions_enabled' => $subscriptions_host !== null,

--- a/configuration/environment_production.php
+++ b/configuration/environment_production.php
@@ -24,6 +24,7 @@ return [
         'brand' => $dotenv->pop('APP_BRAND', 'flusio'),
         'version' => trim(@file_get_contents($app_path . '/VERSION.txt')),
         'cache_path' => $dotenv->pop('APP_CACHE_PATH', $app_path . '/cache'),
+        'media_path' => $dotenv->pop('APP_MEDIA_PATH', $app_path . '/public/media'),
         'demo' => filter_var($dotenv->pop('APP_DEMO', false), FILTER_VALIDATE_BOOLEAN),
         'registrations_opened' => filter_var($dotenv->pop('APP_OPEN_REGISTRATIONS', true), FILTER_VALIDATE_BOOLEAN),
         'subscriptions_enabled' => $subscriptions_host !== null,

--- a/configuration/environment_test.php
+++ b/configuration/environment_test.php
@@ -7,9 +7,11 @@ $db_name = 'flusio_test';
 $temporary_directory = sys_get_temp_dir() . '/flusio/' . \flusio\utils\Random::hex(10);
 $data_directory = $temporary_directory . '/data';
 $cache_directory = $temporary_directory . '/cache';
+$media_directory = $temporary_directory . '/media';
 @mkdir($temporary_directory, 0777, true);
 @mkdir($data_directory, 0777, true);
 @mkdir($cache_directory, 0777, true);
+@mkdir($media_directory, 0777, true);
 
 $subscriptions_host = $dotenv->pop('APP_SUBSCRIPTIONS_HOST');
 
@@ -29,6 +31,7 @@ return [
         'brand' => 'flusio',
         'version' => trim(@file_get_contents($app_path . '/VERSION.txt')),
         'cache_path' => $cache_directory,
+        'media_path' => $media_directory,
         'demo' => false,
         'registrations_opened' => true,
         'subscriptions_enabled' => false, // should be enable on a case-by-case basis

--- a/docker/Dockerfile.php
+++ b/docker/Dockerfile.php
@@ -2,12 +2,22 @@ FROM php:7.4-fpm
 
 ENV COMPOSER_HOME /tmp
 
-RUN apt-get update && \
-    apt-get install -y git libpq-dev libzip-dev unzip libicu-dev locales && \
-    pecl install xdebug && \
-    docker-php-ext-configure intl && \
-    docker-php-ext-install -j$(nproc) intl gettext zip pdo pdo_pgsql && \
-    docker-php-ext-enable xdebug
+RUN apt-get update && apt-get install -y \
+        git \
+        libpq-dev \
+        libzip-dev \
+        unzip \
+        libicu-dev \
+        locales \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libwebp-dev \
+    && pecl install xdebug \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-configure gd --with-webp --with-jpeg --with-freetype \
+    && docker-php-ext-install -j$(nproc) intl gettext zip pdo pdo_pgsql gd \
+    && docker-php-ext-enable xdebug
 
 RUN echo 'en_GB.UTF-8 UTF-8' >> /etc/locale.gen && \
     echo 'fr_FR.UTF-8 UTF-8' >> /etc/locale.gen && \

--- a/docs/production.md
+++ b/docs/production.md
@@ -5,7 +5,7 @@ notions in sysadmin. First, make sure you match with the following
 requirements:
 
 - git, Nginx, PHP 7.3+ and PostgreSQL are installed on your server;
-- PHP requires `intl`, `gettext`, `pdo` and `pdo_pgsql` extensions;
+- PHP requires `intl`, `gettext`, `gd`, `pdo` and `pdo_pgsql` extensions;
 - your PostgreSQL user must have the permission to create a database;
 - flusio must be served over <abbr>HTTPS</abbr>.
 

--- a/env.sample
+++ b/env.sample
@@ -23,6 +23,11 @@ APP_PORT=8000
 # directory presents in the current directory.
 # APP_CACHE_PATH=/tmp
 
+# You can uncomment and change the path for the media files. Default is the
+# media directory presents in the public/ directory. If you change this value,
+# make sure the /media URL path is correctly served by your Web server.
+# APP_MEDIA_PATH=/some/path/to/media
+
 ##################################
 # Database environment variables #
 ##################################

--- a/lib/SpiderBits/src/DomExtractor.php
+++ b/lib/SpiderBits/src/DomExtractor.php
@@ -47,6 +47,37 @@ class DomExtractor
     }
 
     /**
+     * Return the illustration URL of the DOM document.
+     *
+     * @param \SpiderBits\Dom $dom
+     *
+     * @return string
+     */
+    public static function illustration($dom)
+    {
+        $xpath_queries = [
+            // Look for OpenGraph first
+            '/html/head/meta[@property = "og:image"][1]/attribute::content',
+            // Then Twitter meta tag
+            '/html/head/meta[@name = "twitter:image"][1]/attribute::content',
+            // Err, still nothing! Let's try to be more tolerant (e.g. Youtube
+            // puts the meta tags in the body :/)
+            '//meta[@property = "og:image"][1]/attribute::content',
+            '//meta[@name = "twitter:image"][1]/attribute::content',
+        ];
+
+        foreach ($xpath_queries as $query) {
+            $illustration = $dom->select($query);
+            if ($illustration) {
+                return $illustration->text();
+            }
+        }
+
+        // It's hopeless...
+        return '';
+    }
+
+    /**
      * Return the main content of the DOM document.
      *
      * @param \SpiderBits\Dom $dom

--- a/src/Links.php
+++ b/src/Links.php
@@ -472,6 +472,11 @@ class Links
         if (isset($info['reading_time'])) {
             $link->reading_time = $info['reading_time'];
         }
+        if (isset($info['url_illustration'])) {
+            $image_service = new services\Image();
+            $image_filename = $image_service->generatePreviews($info['url_illustration']);
+            $link->image_filename = $image_filename;
+        }
 
         $link_dao = new models\dao\Link();
         $link_dao->save($link);

--- a/src/Links.php
+++ b/src/Links.php
@@ -458,43 +458,20 @@ class Links
             ]);
         }
 
-        $cache_path = \Minz\Configuration::$application['cache_path'];
-        $cache = new \SpiderBits\Cache($cache_path);
-        $url_hash = \SpiderBits\Cache::hash($link->url);
-        $cached_response = $cache->get($url_hash);
+        $fetch_service = new services\Fetch();
+        $info = $fetch_service->fetch($link->url);
 
-        if ($cached_response) {
-            $response = \SpiderBits\Response::fromText($cached_response);
-        } else {
-            $http = new \SpiderBits\Http();
-            $php_os = PHP_OS;
-            $flusio_version = \Minz\Configuration::$application['version'];
-            $http->user_agent = "flusio/{$flusio_version} ({$php_os}; https://github.com/flusio/flusio)";
-            $http->timeout = 5;
-            $response = $http->get($link->url);
-
-            $cache->save($url_hash, (string)$response);
-        }
-
-        if ($response->success) {
-            $content_type = $response->header('content-type');
-            if (utils\Belt::contains($content_type, 'text/html')) {
-                $dom = \SpiderBits\Dom::fromText($response->data);
-                $title = \SpiderBits\DomExtractor::title($dom);
-                if ($title) {
-                    $link->title = $title;
-                }
-
-                $content = \SpiderBits\DomExtractor::content($dom);
-                $words = array_filter(explode(' ', $content));
-                $link->reading_time = intval(count($words) / 200);
-            }
-        } else {
-            $link->fetched_error = $response->data;
-        }
-
-        $link->fetched_code = $response->status;
         $link->fetched_at = \Minz\Time::now();
+        $link->fetched_code = $info['status'];
+        if (isset($info['error'])) {
+            $link->fetched_error = $info['error'];
+        }
+        if (isset($info['title'])) {
+            $link->title = $info['title'];
+        }
+        if (isset($info['reading_time'])) {
+            $link->reading_time = $info['reading_time'];
+        }
 
         $link_dao = new models\dao\Link();
         $link_dao->save($link);

--- a/src/assets/stylesheets/_cards.css
+++ b/src/assets/stylesheets/_cards.css
@@ -68,6 +68,7 @@
     margin-bottom: 0;
 
     font-size: var(--size-normal);
+    line-height: 1.3;
     text-overflow: ellipsis;
 }
 

--- a/src/assets/stylesheets/_cards.css
+++ b/src/assets/stylesheets/_cards.css
@@ -55,6 +55,11 @@
     opacity: 0.5;
 }
 
+.card__image {
+    display: block;
+    width: 100%;
+}
+
 .card__body {
     padding: var(--space-small);
 

--- a/src/assets/stylesheets/_sections.css
+++ b/src/assets/stylesheets/_sections.css
@@ -9,6 +9,17 @@
     padding-bottom: var(--space-larger);
 }
 
+.section__image {
+    display: block;
+    width: 100%;
+    margin-top: var(--space-medium);
+    margin-bottom: var(--space-medium);
+
+    border-radius: 1rem;
+
+    filter: blur(0.7px);
+}
+
 .section__nav {
     display: flex;
     margin: var(--space-small);

--- a/src/cli/Application.php
+++ b/src/cli/Application.php
@@ -31,6 +31,7 @@ class Application
         $router->addRoute('cli', '/topics', 'cli/Topics#index');
         $router->addRoute('cli', '/topics/create', 'cli/Topics#create');
         $router->addRoute('cli', '/topics/delete', 'cli/Topics#delete');
+        $router->addRoute('cli', '/links/refresh', 'cli/Links#refresh');
 
         $this->engine = new \Minz\Engine($router);
         \Minz\Url::setRouter($router);

--- a/src/cli/Links.php
+++ b/src/cli/Links.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace flusio\cli;
+
+use Minz\Response;
+use flusio\models;
+use flusio\services;
+
+/**
+ * @author  Marien Fressinaud <dev@marienfressinaud.fr>
+ * @license http://www.gnu.org/licenses/agpl-3.0.en.html AGPL
+ */
+class Links
+{
+    /**
+     * Refresh the oldest links illustration image
+     *
+     * @request_param integer number
+     *
+     * @response 200
+     */
+    public function refresh($request)
+    {
+        $number = $request->param('number', 10);
+
+        $fetch_service = new services\Fetch();
+        $image_service = new services\Image();
+        $link_dao = new models\dao\Link();
+
+        $db_links = $link_dao->listByOldestFetching($number);
+        $results = [];
+        foreach ($db_links as $db_link) {
+            $link = new models\Link($db_link);
+
+            $result = "Link #{$link->id} ({$link->url}): ";
+
+            $info = $fetch_service->fetch($link->url);
+            $link->fetched_at = \Minz\Time::now();
+            $link->fetched_code = $info['status'];
+            if (isset($info['error'])) {
+                $link->fetched_error = $info['error'];
+                $result .= 'error (see fetched_error for details)';
+            } elseif (isset($info['url_illustration'])) {
+                $image_filename = $image_service->generatePreviews($info['url_illustration']);
+                $link->image_filename = $image_filename;
+                $result .= "fetched {$info['url_illustration']}";
+            } else {
+                $result .= "nothing";
+            }
+
+            $link_dao->save($link);
+
+            $results[] = $result;
+        }
+
+        return Response::text(200, implode("\n", $results));
+    }
+}

--- a/src/cli/System.php
+++ b/src/cli/System.php
@@ -19,6 +19,8 @@ class System
         $usage .= 'REQUEST can be one of the following:' . "\n";
         $usage .= '  /                   Show this help' . "\n";
         $usage .= '  /database/status    Return the status of the DB connection' . "\n";
+        $usage .= '  /links/refresh      Refresh the oldest links (only illustration images)' . "\n";
+        $usage .= '      [-pnumber=NUMBER] where NUMBER is the number of links to refresh (default is 10)' . "\n";
         $usage .= '  /subscriptions/sync Synchronize the overdue subscriptions (or nearly overdue)' . "\n";
         $usage .= '  /system/rollback    Reverse the last migration' . "\n";
         $usage .= '      [-psteps=NUMBER] where NUMBER is the number of rollbacks to apply (default is 1)' . "\n";

--- a/src/cli/System.php
+++ b/src/cli/System.php
@@ -17,24 +17,24 @@ class System
     {
         $usage = 'Usage: php ./cli --request REQUEST [-pKEY=VALUE]...' . "\n\n";
         $usage .= 'REQUEST can be one of the following:' . "\n";
-        $usage .= '  /                 Show this help' . "\n";
-        $usage .= '  /database/status  Return the status of the DB connection' . "\n";
-        $usage .= '  /system/secret    Generate a secure key to be used as APP_SECRET_KEY' . "\n";
-        $usage .= '  /system/rollback  Reverse the last migration' . "\n";
+        $usage .= '  /                   Show this help' . "\n";
+        $usage .= '  /database/status    Return the status of the DB connection' . "\n";
+        $usage .= '  /subscriptions/sync Synchronize the overdue subscriptions (or nearly overdue)' . "\n";
+        $usage .= '  /system/rollback    Reverse the last migration' . "\n";
         $usage .= '      [-psteps=NUMBER] where NUMBER is the number of rollbacks to apply (default is 1)' . "\n";
-        $usage .= '  /system/setup     Initialize or update the system' . "\n";
-        $usage .= '  /topics           List the topics' . "\n";
-        $usage .= '  /topics/create    Create a topic' . "\n";
-        $usage .= '      -plabel=TEXT  where TEXT is a 21-chars max string' . "\n";
-        $usage .= '  /topics/delete    Delete a topic' . "\n";
-        $usage .= '      -pid=ID       where ID is the id of the topic to delete' . "\n";
-        $usage .= '  /users/create     Create a user' . "\n";
-        $usage .= '      -pusername=USERNAME where USERNAME is a 50-chars max string' . "\n";
+        $usage .= '  /system/secret      Generate a secure key to be used as APP_SECRET_KEY' . "\n";
+        $usage .= '  /system/setup       Initialize or update the system' . "\n";
+        $usage .= '  /topics             List the topics' . "\n";
+        $usage .= '  /topics/create      Create a topic' . "\n";
+        $usage .= '      -plabel=TEXT    where TEXT is a 21-chars max string' . "\n";
+        $usage .= '  /topics/delete      Delete a topic' . "\n";
+        $usage .= '      -pid=ID         where ID is the id of the topic to delete' . "\n";
+        $usage .= '  /users/clean        Clean not validated users created NUMBER months ago' . "\n";
+        $usage .= '      [-psince=NUMBER] where NUMBER is the number of months, greater than 0 (default is 1)' . "\n";
+        $usage .= '  /users/create       Create a user' . "\n";
         $usage .= '      -pemail=EMAIL' . "\n";
         $usage .= '      -ppassword=PASSWORD' . "\n";
-        $usage .= '  /users/clean      Clean not validated users created NUMBER months ago' . "\n";
-        $usage .= '      [-psince=NUMBER] where NUMBER is the number of months, greater than 0 (default is 1)' . "\n";
-        $usage .= '  /subscriptions/sync Synchronize the overdue subscriptions (or nearly overdue)';
+        $usage .= '      -pusername=USERNAME where USERNAME is a 50-chars max string';
 
         return Response::text(200, $usage);
     }

--- a/src/migrations/Migration202010220001AddImageFilenameToLinks.php
+++ b/src/migrations/Migration202010220001AddImageFilenameToLinks.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace flusio\migrations;
+
+class Migration202010220001AddImageFilenameToLinks
+{
+    public function migrate()
+    {
+        $database = \Minz\Database::get();
+
+        $database->exec(<<<'SQL'
+            ALTER TABLE links
+            ADD COLUMN image_filename TEXT;
+        SQL);
+
+        return true;
+    }
+
+    public function rollback()
+    {
+        $database = \Minz\Database::get();
+
+        $database->exec(<<<'SQL'
+            ALTER TABLE links
+            DROP COLUMN image_filename;
+        SQL);
+
+        return true;
+    }
+}

--- a/src/models/Image.php
+++ b/src/models/Image.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace flusio\models;
+
+/**
+ * @author  Marien Fressinaud <dev@marienfressinaud.fr>
+ * @license http://www.gnu.org/licenses/agpl-3.0.en.html AGPL
+ */
+class Image
+{
+    /** @var resource */
+    private $resource;
+
+    /** @var integer */
+    private $width;
+
+    /** @var integer */
+    private $height;
+
+    /** @var string */
+    private $type;
+
+    /**
+     * @param resource $resource The image as GD resource
+     * @param string $type jpeg, png or webp
+     */
+    public function __construct($resource, $type)
+    {
+        $this->resource = $resource;
+        $this->type = $type;
+        $this->width = imagesx($resource);
+        $this->height = imagesy($resource);
+    }
+
+    /**
+     * Initialize an image from a string
+     *
+     * @param string $string_image
+     *
+     * @return \flusio\models\Image
+     */
+    public static function fromString($string_image)
+    {
+        $mime = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $string_image);
+        switch (strtolower($mime)) {
+            case 'image/jpg':
+            case 'image/jpeg':
+            case 'image/pjpeg':
+                $type = 'jpeg';
+                break;
+            case 'image/png':
+            case 'image/x-png':
+                $type = 'png';
+                break;
+            case 'image/webp':
+            case 'image/x-webp':
+                $type = 'webp';
+                break;
+            default:
+                throw new \DomainException("The given string doesn’t look like a supported image ({$mime})");
+        }
+
+        $resource = @imagecreatefromstring($string_image);
+        if (!$resource) {
+            throw new \DomainException('Cannot create an image from the given string');
+        }
+
+        return new self($resource, $type);
+    }
+
+    /**
+     * @return string
+     */
+    public function type()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Resize the current image to the given size.
+     *
+     * The image is cropped in the middle to keep the proportion of the image.
+     *
+     * @param integer $width
+     * @param integer $height
+     */
+    public function resize($width, $height)
+    {
+        $new_resource = imagecreatetruecolor($width, $height);
+
+        // Preserve transparency
+        // Code from the Intervention Image library
+        // @see https://github.com/Intervention/image/blob/8ee5f346ce8c6dcbdc7dec443486bd5f6ad924ff/src/Intervention/Image/Gd/Commands/ResizeCommand.php
+        $transparent_index = imagecolortransparent($this->resource);
+        if ($transparent_index !== -1) {
+            $rgba = imagecolorsforindex($new_resource, $transparent_index);
+            $transparent_color = imagecolorallocatealpha(
+                $new_resource,
+                $rgba['red'],
+                $rgba['green'],
+                $rgba['blue'],
+                127
+            );
+            imagefill($new_resource, 0, 0, $transparent_color);
+            imagecolortransparent($new_resource, $transparent_color);
+        } else {
+            imagealphablending($new_resource, false);
+            imagesavealpha($new_resource, true);
+        }
+
+        $src_rect = self::resizeRectangle(
+            [$this->width, $this->height],
+            [$width, $height]
+        );
+
+        imagecopyresampled(
+            $new_resource,
+            $this->resource,
+            0,
+            0,
+            $src_rect['x'],
+            $src_rect['y'],
+            $width,
+            $height,
+            $src_rect['width'],
+            $src_rect['height']
+        );
+
+        imagedestroy($this->resource);
+        $this->resource = $new_resource;
+        $this->width = $width;
+        $this->height = $height;
+    }
+
+    /**
+     * Save the image on disk.
+     *
+     * @param string $filepath
+     */
+    public function save($filepath)
+    {
+        switch ($this->type) {
+            case 'jpeg':
+                imagejpeg($this->resource, $filepath);
+                break;
+            case 'png':
+                imagepng($this->resource, $filepath);
+                break;
+            case 'webp':
+                imagewebp($this->resource, $filepath);
+                break;
+        }
+    }
+
+    /**
+     * Get the src rectangle to be used to resize the initial image
+     *
+     * This function return the bigger rectangle with destination ratio that
+     * fits in the initial rectangle.
+     *
+     * @see https://www.php.net/manual/function.imagecopyresampled
+     *
+     * @param array $initial_size
+     *     The size of the initial image (first value is width, second is height)
+     * @param array $destination_size
+     *     The size of the desired image (first value is width, second is height)
+     *
+     * @return array
+     *     The src rectange to use in imagecopyresampled, array indexes are:
+     *     x, y, width and height.
+     */
+    public static function resizeRectangle($initial_size, $destination_size)
+    {
+        list($initial_width, $initial_height) = $initial_size;
+        list($destination_width, $destination_height) = $destination_size;
+
+        $initial_ratio = $initial_width / $initial_height;
+        $destination_ratio = $destination_width / $destination_height;
+        if ($initial_ratio <= $destination_ratio) {
+            // The current width will entirely fit in the future image, so we
+            // can take the full width. We have to crop the height though
+            // (taking the middle of the image).
+            $src_width = $initial_width;
+            $src_height = $initial_width / $destination_ratio;
+            $src_x = 0;
+            $src_y = ($initial_height - $src_height) / 2;
+        } else {
+            // Same thing, but with height which entirely fit in the future
+            // image.
+            $src_width = $initial_height * $destination_ratio;
+            $src_height = $initial_height;
+            $src_x = ($initial_width - $src_width) / 2;
+            $src_y = 0;
+        }
+
+        return [
+            'x' => $src_x,
+            'y' => $src_y,
+            'width' => $src_width,
+            'height' => $src_height,
+        ];
+    }
+}

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -39,6 +39,10 @@ class Link extends \Minz\Model
             'required' => true,
         ],
 
+        'image_filename' => [
+            'type' => 'string',
+        ],
+
         'fetched_at' => [
             'type' => 'datetime',
         ],

--- a/src/models/dao/Link.php
+++ b/src/models/dao/Link.php
@@ -218,4 +218,24 @@ class Link extends \Minz\DatabaseModel
         ]);
         return $statement->fetchAll();
     }
+
+    /**
+     * Return links with oldest fetched_at date.
+     *
+     * @param integer $number
+     *
+     * @return array
+     */
+    public function listByOldestFetching($number)
+    {
+        $sql = <<<SQL
+             SELECT * FROM links
+             ORDER BY fetched_at
+             LIMIT ?
+        SQL;
+
+        $statement = $this->prepare($sql);
+        $statement->execute([$number]);
+        return $statement->fetchAll();
+    }
 }

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -55,6 +55,7 @@ CREATE TABLE links (
     url TEXT NOT NULL,
     is_public BOOLEAN NOT NULL DEFAULT false,
     reading_time INTEGER NOT NULL DEFAULT 0,
+    image_filename TEXT,
     fetched_at TIMESTAMPTZ,
     fetched_code INTEGER NOT NULL DEFAULT 0,
     fetched_error TEXT,

--- a/src/services/Fetch.php
+++ b/src/services/Fetch.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace flusio\services;
+
+use flusio\utils;
+
+/**
+ * This service helps to fetch links content. It's a wrapper around the
+ * SpiderBits library.
+ *
+ * @author  Marien Fressinaud <dev@marienfressinaud.fr>
+ * @license http://www.gnu.org/licenses/agpl-3.0.en.html AGPL
+ */
+class Fetch
+{
+    /** @var \SpiderBits\Cache */
+    private $cache;
+
+    /** @var \SpiderBits\Http */
+    private $http;
+
+    public function __construct()
+    {
+        $cache_path = \Minz\Configuration::$application['cache_path'];
+        $this->cache = new \SpiderBits\Cache($cache_path);
+
+        $php_os = PHP_OS;
+        $flusio_version = \Minz\Configuration::$application['version'];
+        $this->http = new \SpiderBits\Http();
+        $this->http->user_agent = "flusio/{$flusio_version} ({$php_os}; https://github.com/flusio/flusio)";
+        $this->http->timeout = 5;
+    }
+
+    /**
+     * Fetch URL content and return information about the page
+     *
+     * @param string $url
+     *
+     * @return array Possible keys are:
+     *     - status (always)
+     *     - error
+     *     - title
+     *     - reading_time
+     */
+    public function fetch($url)
+    {
+        // First, we "GET" the URL...
+        $url_hash = \SpiderBits\Cache::hash($url);
+        $cached_response = $this->cache->get($url_hash);
+        if ($cached_response) {
+            // ... via the cache
+            $response = \SpiderBits\Response::fromText($cached_response);
+        } else {
+            // ... or via HTTP
+            $response = $this->http->get($url);
+            // that we add to cache
+            $this->cache->save($url_hash, (string)$response);
+        }
+
+        $info = [
+            'status' => $response->status,
+        ];
+
+        if (!$response->success) {
+            // Okay, Houston, we've had a problem here. Return early, there's
+            // nothing more to do.
+            $info['error'] = $response->data;
+            return $info;
+        }
+
+        $content_type = $response->header('content-type');
+        if (!utils\Belt::contains($content_type, 'text/html')) {
+            // We operate on HTML only
+            return $info; // @codeCoverageIgnore
+        }
+
+        $dom = \SpiderBits\Dom::fromText($response->data);
+
+        // Parse the title from the DOM
+        $title = \SpiderBits\DomExtractor::title($dom);
+        if ($title) {
+            $info['title'] = $title;
+        }
+
+        // And roughly estimate the reading time
+        $content = \SpiderBits\DomExtractor::content($dom);
+        $words = array_filter(explode(' ', $content));
+        $info['reading_time'] = intval(count($words) / 200);
+
+        return $info;
+    }
+}

--- a/src/services/Fetch.php
+++ b/src/services/Fetch.php
@@ -41,6 +41,7 @@ class Fetch
      *     - error
      *     - title
      *     - reading_time
+     *     - url_illustration
      */
     public function fetch($url)
     {
@@ -86,6 +87,13 @@ class Fetch
         $content = \SpiderBits\DomExtractor::content($dom);
         $words = array_filter(explode(' ', $content));
         $info['reading_time'] = intval(count($words) / 200);
+
+        // Get the illustration URL if any
+        $url_illustration = \SpiderBits\DomExtractor::illustration($dom);
+        $url_illustration = \SpiderBits\Url::sanitize($url_illustration);
+        if ($url_illustration) {
+            $info['url_illustration'] = $url_illustration;
+        }
 
         return $info;
     }

--- a/src/services/Image.php
+++ b/src/services/Image.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace flusio\services;
+
+use flusio\utils;
+use flusio\models;
+
+/**
+ * @author  Marien Fressinaud <dev@marienfressinaud.fr>
+ * @license http://www.gnu.org/licenses/agpl-3.0.en.html AGPL
+ */
+class Image
+{
+    /** @var \SpiderBits\Http */
+    private $http;
+
+    /** @var string */
+    private $path_cards;
+
+    /** @var string */
+    private $path_large;
+
+    public function __construct()
+    {
+        $php_os = PHP_OS;
+        $flusio_version = \Minz\Configuration::$application['version'];
+        $this->http = new \SpiderBits\Http();
+        $this->http->user_agent = "flusio/{$flusio_version} ({$php_os}; https://github.com/flusio/flusio)";
+        $this->http->timeout = 5;
+
+        $media_path = \Minz\Configuration::$application['media_path'];
+        $this->path_cards = "{$media_path}/cards";
+        $this->path_large = "{$media_path}/large";
+        if (!file_exists($this->path_cards)) {
+            @mkdir($this->path_cards, 0755, true);
+        }
+        if (!file_exists($this->path_large)) {
+            @mkdir($this->path_large, 0755, true);
+        }
+    }
+
+    /**
+     * Generate preview images
+     *
+     * @param string $image_url
+     *
+     * @return string
+     *     The generated image filename on the disk (or an empty string on failure)
+     */
+    public function generatePreviews($image_url)
+    {
+        $url_hash = \SpiderBits\Cache::hash($image_url);
+        $card_image_filepath = $this->path_cards . '/' . $url_hash;
+        $large_image_filepath = $this->path_large . '/' . $url_hash;
+        $card_file_exists = glob($card_image_filepath . '.*');
+        $large_file_exists = glob($large_image_filepath . '.*');
+
+        if ($card_file_exists && $large_file_exists) {
+            return basename($card_file_exists[0]);
+        }
+
+        $response = $this->http->get($image_url);
+        if (!$response->success) {
+            return '';
+        }
+
+        try {
+            // We generate two different images from the source to keep the
+            // quality as high as possible
+            $card_image = models\Image::fromString($response->data);
+            $card_image->resize(300, 150);
+            $card_image->save($card_image_filepath . '.' . $card_image->type());
+
+            $large_image = models\Image::fromString($response->data);
+            $large_image->resize(1000, 200);
+            $large_image->save($large_image_filepath . '.' . $large_image->type());
+
+            return $url_hash . '.' . $card_image->type();
+        } catch (\DomainException $e) {
+            \Minz\Log::warning("Can’t save preview image ({$image_url})");
+            return '';
+        }
+    }
+}

--- a/src/utils/view_helpers.php
+++ b/src/utils/view_helpers.php
@@ -109,6 +109,27 @@ function url_asset($filename)
 }
 
 /**
+ * Return the relative URL for a link image
+ *
+ * @param string $type Either 'cards' or 'large'
+ * @param string $filename The URL saved in link->image_filename
+ *
+ * @return string
+ */
+function url_link_image($type, $filename)
+{
+    $media_path = \Minz\Configuration::$application['media_path'];
+    $filepath = "{$media_path}/{$type}/{$filename}";
+    $modification_time = @filemtime($filepath);
+    $file_url = \Minz\Url::path() . "/media/{$type}/{$filename}";
+    if ($modification_time) {
+        return $file_url . '?' . $modification_time;
+    } else {
+        return $file_url;
+    }
+}
+
+/**
  * Format news preferences so it's readable for humans.
  *
  * @param \flusio\models\NewsPreferences $preferences

--- a/src/views/collections/show.phtml
+++ b/src/views/collections/show.phtml
@@ -105,6 +105,12 @@
         <div class="cards">
             <?php foreach ($links as $link): ?>
                 <div class="card">
+                    <?php if ($link->image_filename): ?>
+                        <a class="anchor--hidden" href="<?= url('link', ['id' => $link->id]) ?>" tabindex="-1">
+                            <img class="card__image" alt="" src="<?= url_link_image('cards', $link->image_filename) ?>" />
+                        </a>
+                    <?php endif; ?>
+
                     <div class="card__body">
                         <h2 class="card__title">
                             <a class="anchor--hidden" href="<?= url('link', ['id' => $link->id]) ?>" tabindex="-1">

--- a/src/views/collections/show_bookmarks.phtml
+++ b/src/views/collections/show_bookmarks.phtml
@@ -37,6 +37,12 @@
                     data-link-card-bookmark-action="<?= url('bookmark link', ['id' => $link->id]) ?>"
                     data-link-card-unbookmark-action="<?= url('unbookmark link', ['id' => $link->id]) ?>"
                 >
+                    <?php if ($link->image_filename): ?>
+                        <a class="anchor--hidden" href="<?= url('link', ['id' => $link->id]) ?>" tabindex="-1">
+                            <img class="card__image" alt="" src="<?= url_link_image('cards', $link->image_filename) ?>" />
+                        </a>
+                    <?php endif; ?>
+
                     <div class="card__body">
                         <h2 class="card__title">
                             <a class="anchor--hidden" href="<?= url('link', ['id' => $link->id]) ?>" tabindex="-1">

--- a/src/views/collections/show_public.phtml
+++ b/src/views/collections/show_public.phtml
@@ -74,6 +74,12 @@
         <div class="cards">
             <?php foreach ($links as $link): ?>
                 <div class="card">
+                    <?php if ($link->image_filename): ?>
+                        <a class="anchor--hidden" href="<?= url('link', ['id' => $link->id]) ?>" tabindex="-1">
+                            <img class="card__image" alt="" src="<?= url_link_image('cards', $link->image_filename) ?>" />
+                        </a>
+                    <?php endif; ?>
+
                     <div class="card__body">
                         <h2 class="card__title">
                             <a class="anchor--hidden" href="<?= url('link', ['id' => $link->id]) ?>" tabindex="-1">

--- a/src/views/links/show.phtml
+++ b/src/views/links/show.phtml
@@ -71,6 +71,14 @@
         </details>
     </nav>
 
+    <?php if ($link->image_filename): ?>
+        <img
+            class="section__image"
+            alt=""
+            src="<?= url_link_image('large', $link->image_filename) ?>"
+        />
+    <?php endif; ?>
+
     <div class="section__title">
         <h1><?= $this->protect($link->title) ?></h1>
     </div>

--- a/src/views/links/show_public.phtml
+++ b/src/views/links/show_public.phtml
@@ -21,6 +21,14 @@
         <div class="section__nav-separator"></div>
     </nav>
 
+    <?php if ($link->image_filename): ?>
+        <img
+            class="section__image"
+            alt=""
+            src="<?= url_link_image('large', $link->image_filename) ?>"
+        />
+    <?php endif; ?>
+
     <div class="section__title">
         <h1><?= $this->protect($link->title) ?></h1>
     </div>

--- a/tests/LinksTest.php
+++ b/tests/LinksTest.php
@@ -900,6 +900,31 @@ class LinksTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expected_title, $db_link['title']);
     }
 
+    public function testFetchDownloadsOpenGraphIllustration()
+    {
+        $link_dao = new models\dao\Link();
+
+        $user = $this->login();
+        $link_id = $this->create('link', [
+            'user_id' => $user->id,
+            'url' => 'https://flus.fr/carnet/flus-media-social-citoyen.html',
+            'image_filename' => null,
+        ]);
+
+        $response = $this->appRun('post', "/links/{$link_id}/fetch", [
+            'csrf' => $user->csrf,
+        ]);
+
+        $link = new models\Link($link_dao->find($link_id));
+        $image_filename = $link->image_filename;
+        $this->assertNotNull($image_filename);
+        $media_path = \Minz\Configuration::$application['media_path'];
+        $card_filepath = "{$media_path}/cards/{$image_filename}";
+        $large_filepath = "{$media_path}/large/{$image_filename}";
+        $this->assertTrue(file_exists($card_filepath));
+        $this->assertTrue(file_exists($large_filepath));
+    }
+
     public function testFetchDoesNotChangeTitleIfUnreachable()
     {
         $link_dao = new models\dao\Link();

--- a/tests/lib/SpiderBits/DomExtractorTest.php
+++ b/tests/lib/SpiderBits/DomExtractorTest.php
@@ -86,6 +86,36 @@ class DomExtractorTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('', $title);
     }
 
+    public function testIllustrationTakesOgImage()
+    {
+        $dom = Dom::fromText(<<<HTML
+            <html>
+                <head>
+                    <meta property="og:image" content="https://domain.com/image.jpg" />
+                </head>
+            </html>
+        HTML);
+
+        $illustration = DomExtractor::illustration($dom);
+
+        $this->assertSame('https://domain.com/image.jpg', $illustration);
+    }
+
+    public function testIllustrationTakesTwitterImage()
+    {
+        $dom = Dom::fromText(<<<HTML
+            <html>
+                <head>
+                    <meta name="twitter:image" content="https://domain.com/image.jpg" />
+                </head>
+            </html>
+        HTML);
+
+        $illustration = DomExtractor::illustration($dom);
+
+        $this->assertSame('https://domain.com/image.jpg', $illustration);
+    }
+
     public function testContentReturnsMainTag()
     {
         $dom = Dom::fromText(<<<HTML

--- a/tests/models/ImageTest.php
+++ b/tests/models/ImageTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace flusio\models;
+
+class ImageTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider resizeProvider
+     */
+    public function testResizeRectangle($initial_size, $destination_size, $expected_rect)
+    {
+        $src_rect = Image::resizeRectangle($initial_size, $destination_size);
+
+        $this->assertSame($expected_rect['x'], $src_rect['x']);
+        $this->assertSame($expected_rect['y'], $src_rect['y']);
+        $this->assertSame($expected_rect['width'], $src_rect['width']);
+        $this->assertSame($expected_rect['height'], $src_rect['height']);
+    }
+
+    public function resizeProvider()
+    {
+        return [
+            [
+                [800, 600],
+                [300, 150],
+                [
+                    'x' => 0,
+                    'y' => 100,
+                    'width' => 800,
+                    'height' => 400,
+                ],
+            ],
+            [
+                [800, 600],
+                [1000, 200],
+                [
+                    'x' => 0,
+                    'y' => 220,
+                    'width' => 800,
+                    'height' => 160,
+                ],
+            ],
+            [
+                [300, 150],
+                [300, 150],
+                [
+                    'x' => 0,
+                    'y' => 0,
+                    'width' => 300,
+                    'height' => 150,
+                ],
+            ],
+            [
+                [1500, 600],
+                [300, 150],
+                [
+                    'x' => 150,
+                    'y' => 0,
+                    'width' => 1200,
+                    'height' => 600,
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:

- Reduce line-height of cards titles
- Reorganize commands in CLI usage action
- Add PHP gd extension requirement
- Reorganize link fetching code (extraction in a dedicated service)
- Download and generate preview image of Open Graph images
- Display images in collections and link pages (not in news yet, in a following PR)
- Add a command to refresh links images

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written
- [x] commit messages are clear
- [x] documentation is updated (including migration notes)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
