### PR TITLE
imp: Move news preferences in a modal

### DIFF
--- a/src/views/news_links/index.phtml
+++ b/src/views/news_links/index.phtml
@@ -17,9 +17,16 @@
             </p>
 
             <p>
-                <a href="<?= url('news preferences') ?>">
+                <button
+                    data-controller="modal-opener"
+                    data-action="modal-opener#fetch"
+                    data-modal-opener-href="<?= url('news preferences') ?>"
+                    aria-haspopup="dialog"
+                    aria-controls="modal"
+                    title="<?= _('Add to collections') ?>"
+                >
                     <?= _('Configure') ?>
-                </a>
+                </button>
             </p>
         </div>
     <?php endif; ?>

--- a/src/views/news_links/preferences.phtml
+++ b/src/views/news_links/preferences.phtml
@@ -7,7 +7,7 @@
 
 <div class="section">
     <div class="section__title">
-        <h1><?= _('News preference') ?></h1>
+        <h1 id="modal-title"><?= _('News preference') ?></h1>
     </div>
 
     <form method="post" action="<?= url('update news preferences') ?>">
@@ -100,9 +100,12 @@
                 <?= _('Save') ?>
             </button>
 
-            <a href="<?= url('news') ?>">
+            <a href="<?= url('news') ?>" class="no-modal">
                 <?= _('Cancel and go back to the news') ?>
             </a>
+            <button type="button" class="only-modal" data-action="modal#close">
+                <?= _('Cancel and go back to the news') ?>
+            </button>
         </div>
     </form>
 </div>


### PR DESCRIPTION
Changes proposed in this pull request:

- Move news preferences in a modal

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written N/A
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
