### PR TITLE
fix: Fix popup menu position on mobile

### DIFF
--- a/src/assets/stylesheets/_layout.css
+++ b/src/assets/stylesheets/_layout.css
@@ -22,12 +22,19 @@
 }
 
 .layout__header--connected .header__link {
+    height: var(--height-header);
     padding: var(--space-small);
 
     text-decoration: none;
 
     border-top: 0.5rem solid transparent;
     border-bottom: 0.5rem solid transparent;
+}
+
+@media (min-width: 800px) {
+    .layout__header--connected .header__link {
+        height: auto;
+    }
 }
 
 .layout__header--connected .header__link--icon {

--- a/src/assets/stylesheets/_popup.css
+++ b/src/assets/stylesheets/_popup.css
@@ -16,7 +16,7 @@
     position: fixed;
     z-index: 10;
     right: 0;
-    bottom: 5.5rem;
+    bottom: var(--height-header);
     left: 0;
 
     padding: var(--space-medium) var(--space-small);

--- a/src/assets/stylesheets/_variables.css
+++ b/src/assets/stylesheets/_variables.css
@@ -72,6 +72,7 @@
 
     --content-width: 1000px;
 
+    --height-header: 5.5rem;
     --height-bottom-line: 1rem;
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:

Force the height of navbar on mobile and put the popup menu bottom position to this height to avoid a 1px space between the two of them.

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written N/A
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
