### PR TITLE
imp: Pick public news links in private collections

### DIFF
--- a/src/models/dao/Link.php
+++ b/src/models/dao/Link.php
@@ -185,22 +185,18 @@ class Link extends \Minz\DatabaseModel
     public function listFromTopicsForNews($user_id)
     {
         $sql = <<<SQL
-             SELECT l.* FROM links l, collections c, links_to_collections lc, collections_to_topics ct
+             SELECT l.* FROM links l, links_to_collections lc, collections_to_topics ct
 
-             WHERE ct.collection_id = lc.collection_id
-             AND ct.topic_id IN (
+             WHERE ct.topic_id IN (
                 SELECT ut.topic_id FROM users_to_topics ut
                 WHERE ut.user_id = :user_id
              )
 
+             AND ct.collection_id = lc.collection_id
              AND lc.link_id = l.id
-             AND lc.collection_id = c.id
 
              AND l.is_public = true
-             AND c.is_public = true
-
-             AND c.user_id != :user_id
-
+             AND l.user_id != :user_id
              AND l.url NOT IN (
                  SELECT nl.url FROM news_links nl
                  WHERE nl.user_id = :user_id

--- a/tests/services/NewsPickerTest.php
+++ b/tests/services/NewsPickerTest.php
@@ -104,7 +104,6 @@ class NewsPickerTest extends \PHPUnit\Framework\TestCase
         $collection_id1 = $this->create('collection', [
             'user_id' => $this->other_user->id,
             'type' => 'collection',
-            'is_public' => 1,
         ]);
         $this->create('link_to_collection', [
             'collection_id' => $collection_id1,
@@ -123,7 +122,6 @@ class NewsPickerTest extends \PHPUnit\Framework\TestCase
         $collection_id2 = $this->create('collection', [
             'user_id' => $this->other_user->id,
             'type' => 'collection',
-            'is_public' => 1,
         ]);
         $this->create('link_to_collection', [
             'collection_id' => $collection_id2,
@@ -338,7 +336,6 @@ class NewsPickerTest extends \PHPUnit\Framework\TestCase
         $collection_id = $this->create('collection', [
             'user_id' => $this->other_user->id,
             'type' => 'collection',
-            'is_public' => 1,
         ]);
         $this->create('link_to_collection', [
             'collection_id' => $collection_id,
@@ -462,7 +459,7 @@ class NewsPickerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(0, count($db_links));
     }
 
-    public function testPickDoesNotSelectFromTopicsIfCollectionIsOwned()
+    public function testPickDoesNotSelectFromTopicsIfLinkIsOwned()
     {
         $news_picker = new NewsPicker($this->user);
         $topic_id = $this->create('topic');
@@ -480,7 +477,6 @@ class NewsPickerTest extends \PHPUnit\Framework\TestCase
         $collection_id = $this->create('collection', [
             'user_id' => $this->user->id,
             'type' => 'collection',
-            'is_public' => 1,
         ]);
         $this->create('link_to_collection', [
             'collection_id' => $collection_id,
@@ -493,8 +489,40 @@ class NewsPickerTest extends \PHPUnit\Framework\TestCase
 
         $db_links = $news_picker->pick();
 
-        // because the user owns the collection, we don't get the link
-        // associated to the topic
+        // because the user owns the link, it’s not returned by the picker
+        $this->assertSame(0, count($db_links));
+    }
+
+    public function testPickDoesNotSelectFromTopicsIfLinkIsPrivate()
+    {
+        $news_picker = new NewsPicker($this->user);
+        $topic_id = $this->create('topic');
+        // make the user interested by topic1
+        $this->create('user_to_topic', [
+            'user_id' => $this->user->id,
+            'topic_id' => $topic_id,
+        ]);
+        // create a link to a collection associated to topic
+        $link_id = $this->create('link', [
+            'user_id' => $this->other_user->id,
+            'reading_time' => 10,
+            'is_public' => 0,
+        ]);
+        $collection_id = $this->create('collection', [
+            'user_id' => $this->other_user->id,
+            'type' => 'collection',
+        ]);
+        $this->create('link_to_collection', [
+            'collection_id' => $collection_id,
+            'link_id' => $link_id,
+        ]);
+        $this->create('collection_to_topic', [
+            'collection_id' => $collection_id,
+            'topic_id' => $topic_id,
+        ]);
+
+        $db_links = $news_picker->pick();
+
         $this->assertSame(0, count($db_links));
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

In the SQL request:

- Don't check anymore that the collections are public
- Exclude links owned by the user (instead of collection owned by him)
- Remove the now useless join of collections table
- Reorganize the SQL where clauses

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
