### PR TITLE
tec: Add service param in subscription login request

### DIFF
--- a/src/services/Subscriptions.php
+++ b/src/services/Subscriptions.php
@@ -71,6 +71,7 @@ class Subscriptions
     {
         $response = $this->http->get($this->host . '/api/account/login-url', [
             'account_id' => $account_id,
+            'service' => 'flusio',
         ], [
             'auth_basic' => $this->private_key . ':',
         ]);

--- a/tests/lib/SpiderBits/HttpTest.php
+++ b/tests/lib/SpiderBits/HttpTest.php
@@ -91,7 +91,7 @@ class HttpTest extends \PHPUnit\Framework\TestCase
                 // with my own domain (http is redirected to https)
                 'http://flus.fr/',
                 200,
-                'Flus, média social citoyen',
+                'Flus, média social de veille',
                 ['content-type' => 'text/html;charset=UTF-8'],
             ],
             [


### PR DESCRIPTION
Changes proposed in this pull request:

- Add service param in subscription login request

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] new tests are written N/A
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
