### PR TITLE
fix: Create subscription accounts on sync

### DIFF
--- a/src/models/dao/User.php
+++ b/src/models/dao/User.php
@@ -78,7 +78,8 @@ class User extends \Minz\DatabaseModel
     }
 
     /**
-     * Return users with subscriptions expired_at before a given date
+     * Return users with subscriptions expired_at before a given date. It does
+     * not return users with no account id (you should create them first).
      *
      * @param \DateTime $before_this_date
      *
@@ -86,7 +87,11 @@ class User extends \Minz\DatabaseModel
      */
     public function listBySubscriptionExpiredAtBefore($before_this_date)
     {
-        $sql = "SELECT * FROM users WHERE subscription_expired_at <= ?";
+        $sql = <<<'SQL'
+            SELECT * FROM users
+            WHERE subscription_expired_at <= ?
+            AND subscription_account_id IS NOT NULL
+        SQL;
         $statement = $this->prepare($sql);
         $statement->execute([
             $before_this_date->format(\Minz\Model::DATETIME_FORMAT),


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a loop on sync to create subscription accounts if missing
- Don't return db users on `listBySubscriptionExpiredAtBefore()` if they don't have subscription account id
- Improve feedback messages

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens  N/A
- [x] new tests are written
- [x] French locale is synchronized  N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
