### PR TITLE
imp: Add aria-current page on concerned elements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,11 @@ endif
 .PHONY: start
 start: ## Start a development server (use Docker)
 	@echo "Running webserver on http://localhost:8000"
-	docker-compose -f docker/docker-compose.yml up
+	docker-compose -p flusio -f docker/docker-compose.yml up
 
 .PHONY: stop
 stop: ## Stop and clean Docker server
-	docker-compose -f docker/docker-compose.yml down
+	docker-compose -p flusio -f docker/docker-compose.yml down
 
 .PHONY: install
 install: ## Install the dependencies

--- a/docker/bin/cli
+++ b/docker/bin/cli
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-USER=$(id -u):$(id -g) docker-compose -f ./docker/docker-compose.yml run --rm --no-deps php php ./cli $*
+USER=$(id -u):$(id -g) docker-compose -p flusio -f ./docker/docker-compose.yml run --rm --no-deps php php ./cli $*

--- a/docker/bin/composer
+++ b/docker/bin/composer
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-USER=$(id -u):$(id -g) docker-compose -f ./docker/docker-compose.yml run --rm --no-deps php composer $*
+USER=$(id -u):$(id -g) docker-compose -p flusio -f ./docker/docker-compose.yml run --rm --no-deps php composer $*

--- a/docker/bin/npm
+++ b/docker/bin/npm
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-USER=$(id -u):$(id -g) docker-compose -f ./docker/docker-compose.yml run --rm --no-deps bundler npm $*
+USER=$(id -u):$(id -g) docker-compose -p flusio -f ./docker/docker-compose.yml run --rm --no-deps bundler npm $*

--- a/docker/bin/php
+++ b/docker/bin/php
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-USER=$(id -u):$(id -g) docker-compose -f ./docker/docker-compose.yml run --rm --no-deps php php $*
+USER=$(id -u):$(id -g) docker-compose -p flusio -f ./docker/docker-compose.yml run --rm --no-deps php php $*

--- a/src/Application.php
+++ b/src/Application.php
@@ -198,11 +198,11 @@ class Application
             'current_locale' => $locale,
             'current_user' => $current_user,
             'current_tab' => null,
+            'current_page' => null,
             'styles' => [],
             'javascript_configuration' => json_encode(include('utils/javascript_configuration.php')),
             'no_layout' => $request->header('HTTP_X_REQUESTED_WITH') === 'XMLHttpRequest',
             'subscriptions_enabled' => $app_conf['subscriptions_enabled'],
-            'banner' => true,
             'demo' => $app_conf['demo'],
             'registrations_opened' => $app_conf['registrations_opened'],
         ]);

--- a/src/views/_layouts/base.phtml
+++ b/src/views/_layouts/base.phtml
@@ -23,9 +23,9 @@
             'current_action_pointer' => $current_action_pointer,
             'current_locale' => $current_locale,
             'current_tab' => $current_tab,
+            'current_page' => $current_page,
             'canonical' => $canonical,
             'styles' => $styles,
-            'banner' => $banner,
             'back' => $back,
         ]);
     }

--- a/src/views/_layouts/connected.phtml
+++ b/src/views/_layouts/connected.phtml
@@ -63,7 +63,7 @@
                 </div>
             <?php endif; ?>
 
-            <?php if (!$current_user->validated_at && $banner): ?>
+            <?php if (!$current_user->validated_at && $current_page !== 'account validation'): ?>
                 <div class="layout__banner">
                     <a class="banner__container banner__container--anchor" href="<?= url('account validation') ?>">
                         <?= _('You must validate your account&nbsp;→') ?>
@@ -77,6 +77,7 @@
 
                     <a
                         class="header__link header__link--icon icon icon--anchor icon--tree <?= $current_tab === 'news' ? 'header__link--active' : '' ?>"
+                        <?= $current_page === 'news' ? 'aria-current="page"' : '' ?>
                         href="<?= url('news') ?>"
                     >
                         <span class="no-mobile">
@@ -86,6 +87,7 @@
 
                     <a
                         class="header__link header__link--icon icon icon--anchor icon--bookmark <?= $current_tab === 'bookmarks' ? 'header__link--active' : '' ?>"
+                        <?= $current_page === 'bookmarks' ? 'aria-current="page"' : '' ?>
                         href="<?= url('bookmarks') ?>"
                     >
                         <span class="no-mobile">
@@ -95,6 +97,7 @@
 
                     <a
                         class="header__link header__link--icon icon icon--anchor icon--collection <?= $current_tab === 'collections' ? 'header__link--active' : '' ?>"
+                        <?= $current_page === 'collections' ? 'aria-current="page"' : '' ?>
                         href="<?= url('collections') ?>"
                     >
                         <span class="no-mobile">
@@ -121,20 +124,36 @@
                         <nav class="popup__container popup__container--left">
                             <div class="popup__title"><?= $this->protect($current_user->username) ?></div>
 
-                            <a class="popup__item popup__item--link icon icon--avatar" href="<?= url('profile') ?>">
+                            <a
+                                class="popup__item popup__item--link icon icon--avatar"
+                                <?= $current_page === 'profile' ? 'aria-current="page"' : '' ?>
+                                href="<?= url('profile') ?>"
+                            >
                                 <?= _('Profile') ?>
                             </a>
 
-                            <a class="popup__item popup__item--link icon icon--key" href="<?= url('security') ?>">
+                            <a
+                                class="popup__item popup__item--link icon icon--key"
+                                <?= $current_page === 'security' ? 'aria-current="page"' : '' ?>
+                                href="<?= url('security') ?>"
+                            >
                                 <?= _('Login & security') ?>
                             </a>
 
                             <?php if ($subscriptions_enabled): ?>
-                                <a class="popup__item popup__item--link icon icon--credit-card" href="<?= url('account') ?>">
+                                <a
+                                    class="popup__item popup__item--link icon icon--credit-card"
+                                    <?= $current_page === 'account' ? 'aria-current="page"' : '' ?>
+                                    href="<?= url('account') ?>"
+                                >
                                     <?= _('Account & subscription') ?>
                                 </a>
                             <?php else: ?>
-                                <a class="popup__item popup__item--link icon icon--details" href="<?= url('account') ?>">
+                                <a
+                                    class="popup__item popup__item--link icon icon--credit-details"
+                                    <?= $current_page === 'account' ? 'aria-current="page"' : '' ?>
+                                    href="<?= url('account') ?>"
+                                >
                                     <?= _('Account') ?>
                                 </a>
                             <?php endif; ?>
@@ -152,6 +171,7 @@
 
                     <a
                         class="header__link header__link--featured header__link--icon icon icon--anchor icon--plus-circle"
+                        <?= $current_page === 'new link' ? 'aria-current="page"' : '' ?>
                         href="<?= url('new link') ?>"
                         title="<?= _('Add a link') ?>"
                     >

--- a/src/views/_layouts/connected_blocked.phtml
+++ b/src/views/_layouts/connected_blocked.phtml
@@ -63,7 +63,7 @@
                 </div>
             <?php endif; ?>
 
-            <?php if (!$current_user->validated_at && $banner): ?>
+            <?php if (!$current_user->validated_at && $current_page !== 'account validation'): ?>
                 <div class="layout__banner">
                     <a class="banner__container banner__container--anchor" href="<?= url('account validation') ?>">
                         <?= _('You must validate your account&nbsp;→') ?>
@@ -101,20 +101,36 @@
                         <nav class="popup__container popup__container--left">
                             <div class="popup__title"><?= $this->protect($current_user->username) ?></div>
 
-                            <a class="popup__item popup__item--link icon icon--avatar" href="<?= url('profile') ?>">
+                            <a
+                                class="popup__item popup__item--link icon icon--avatar"
+                                <?= $current_page === 'profile' ? 'aria-current="page"' : '' ?>
+                                href="<?= url('profile') ?>"
+                            >
                                 <?= _('Profile') ?>
                             </a>
 
-                            <a class="popup__item popup__item--link icon icon--key" href="<?= url('security') ?>">
+                            <a
+                                class="popup__item popup__item--link icon icon--key"
+                                <?= $current_page === 'security' ? 'aria-current="page"' : '' ?>
+                                href="<?= url('security') ?>"
+                            >
                                 <?= _('Login & security') ?>
                             </a>
 
                             <?php if ($subscriptions_enabled): ?>
-                                <a class="popup__item popup__item--link icon icon--credit-card" href="<?= url('account') ?>">
+                                <a
+                                    class="popup__item popup__item--link icon icon--credit-card"
+                                    <?= $current_page === 'account' ? 'aria-current="page"' : '' ?>
+                                    href="<?= url('account') ?>"
+                                >
                                     <?= _('Account & subscription') ?>
                                 </a>
                             <?php else: ?>
-                                <a class="popup__item popup__item--link icon icon--details" href="<?= url('account') ?>">
+                                <a
+                                    class="popup__item popup__item--link icon icon--credit-details"
+                                    <?= $current_page === 'account' ? 'aria-current="page"' : '' ?>
+                                    href="<?= url('account') ?>"
+                                >
                                     <?= _('Account') ?>
                                 </a>
                             <?php endif; ?>

--- a/src/views/_layouts/not_connected.phtml
+++ b/src/views/_layouts/not_connected.phtml
@@ -76,9 +76,13 @@
 
                     <div class="header__separator"></div>
 
-                    <?php if ($registrations_opened): ?>
+                    <?php if ($registrations_opened && $current_page !== 'registration'): ?>
                         <a class="header__link no-mobile" href="<?= url('registration') ?>">
                             <?= _('Sign up') ?>
+                        </a>
+                    <?php elseif ($current_page !== 'login'): ?>
+                        <a class="header__link no-mobile" href="<?= url('login') ?>">
+                            <?= _('Login') ?>
                         </a>
                     <?php endif; ?>
 

--- a/src/views/collections/discover.phtml
+++ b/src/views/collections/discover.phtml
@@ -74,7 +74,11 @@
                     <?php foreach ($pagination->pages() as $page): ?>
                         <?php if ($page['type'] === 'number'): ?>
                             <li class="pagination__item pagination__item--number <?= $pagination->isPageCurrent($page['number']) ? 'pagination__item--current' : '' ?>">
-                                <a class="pagination__link" href="<?= url('discover collections', ['page' => $page['number']]) ?>">
+                                <a
+                                    class="pagination__link"
+                                    href="<?= url('discover collections', ['page' => $page['number']]) ?>"
+                                    <?= $pagination->isPageCurrent($page['number']) ? 'aria-current="page"' : '' ?>
+                                >
                                     <?= $page['number'] ?>
                                 </a>
                             </li>

--- a/src/views/collections/index.phtml
+++ b/src/views/collections/index.phtml
@@ -2,6 +2,7 @@
     $this->layout('base.phtml', [
         'title' => _('Collections'),
         'current_tab' => 'collections',
+        'current_page' => 'collections',
     ]);
 ?>
 

--- a/src/views/collections/show_bookmarks.phtml
+++ b/src/views/collections/show_bookmarks.phtml
@@ -2,6 +2,7 @@
     $this->layout('base.phtml', [
         'title' => _('Bookmarks'),
         'current_tab' => 'bookmarks',
+        'current_page' => 'bookmarks',
     ]);
 ?>
 

--- a/src/views/links/new.phtml
+++ b/src/views/links/new.phtml
@@ -1,7 +1,7 @@
 <?php
     $this->layout('base.phtml', [
         'title' => _('New link'),
-        'current_tab' => 'new link',
+        'current_page' => 'new link',
         'back' => [
             'href' => url('news'),
             'label' => _('Back'),

--- a/src/views/my/account/show.phtml
+++ b/src/views/my/account/show.phtml
@@ -1,6 +1,7 @@
 <?php
     $this->layout('base.phtml', [
         'title' => $subscriptions_enabled ? _('Account & subscription') : _('Account'),
+        'current_page' => 'account',
     ]);
 ?>
 

--- a/src/views/my/account/validation.phtml
+++ b/src/views/my/account/validation.phtml
@@ -1,7 +1,7 @@
 <?php
     $this->layout('base.phtml', [
         'title' => _('Account validation'),
-        'banner' => false,
+        'current_page' => 'account validation',
         'back' => [
             'href' => url('account'),
             'label' => _('Account'),

--- a/src/views/my/profile/show.phtml
+++ b/src/views/my/profile/show.phtml
@@ -2,6 +2,7 @@
     $this->layout('base.phtml', [
         'title' => _('Profile'),
         'current_locale' => $current_locale,
+        'current_page' => 'profile',
     ]);
 ?>
 

--- a/src/views/my/security/show_confirmed.phtml
+++ b/src/views/my/security/show_confirmed.phtml
@@ -1,6 +1,7 @@
 <?php
     $this->layout('base.phtml', [
         'title' => _('Login & security'),
+        'current_page' => 'security',
     ]);
 ?>
 

--- a/src/views/my/security/show_to_confirm.phtml
+++ b/src/views/my/security/show_to_confirm.phtml
@@ -1,6 +1,7 @@
 <?php
     $this->layout('base.phtml', [
         'title' => _('Login & security'),
+        'current_page' => 'security',
     ]);
 ?>
 

--- a/src/views/news_links/index.phtml
+++ b/src/views/news_links/index.phtml
@@ -2,6 +2,7 @@
     $this->layout('base.phtml', [
         'title' => _('News'),
         'current_tab' => 'news',
+        'current_page' => 'news',
     ]);
 ?>
 

--- a/src/views/registrations/new.phtml
+++ b/src/views/registrations/new.phtml
@@ -1,6 +1,7 @@
 <?php
     $this->layout('base.phtml', [
         'title' => _('Sign up'),
+        'current_page' => 'registration',
     ]);
 ?>
 

--- a/src/views/sessions/new.phtml
+++ b/src/views/sessions/new.phtml
@@ -1,6 +1,7 @@
 <?php
     $this->layout('base.phtml', [
         'title' => _('Log in'),
+        'current_page' => 'login',
     ]);
 ?>
 


### PR DESCRIPTION
Changes proposed in this pull request:

- tec: Set docker-compose project name to flusio
- Add a global `current_page` attribute to views
- Add aria-current page on pagination and header items
- Remove global attribute `banner` (now useless)
- Show a "login" link when on registration page

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written N/A
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
