### PR TITLE
fix: Don't redirect when discover page is empty

### DIFF
--- a/src/utils/Pagination.php
+++ b/src/utils/Pagination.php
@@ -42,7 +42,7 @@ class Pagination
         } else {
             $this->number_per_page = $number_per_page;
         }
-        $this->total_pages = intval(ceil($this->number_elements / $this->number_per_page));
+        $this->total_pages = max(1, intval(ceil($this->number_elements / $this->number_per_page)));
         if ($current_page < 1) {
             $this->current_page = 1;
         } elseif ($current_page > $this->total_pages) {
@@ -51,6 +51,14 @@ class Pagination
             $this->current_page = $current_page;
         }
         $this->current_offset = $this->number_per_page * ($this->current_page - 1);
+    }
+
+    /**
+     * @return integer
+     */
+    public function totalPages()
+    {
+        return $this->total_pages;
     }
 
     /**

--- a/tests/CollectionsTest.php
+++ b/tests/CollectionsTest.php
@@ -972,6 +972,32 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertStringNotContainsString('2 links', $output);
     }
 
+    public function testDiscoverRedirectsIfPageIsOutOfBound()
+    {
+        $user = $this->login();
+        $collection_name = $this->fake('sentence');
+        $other_user_id = $this->create('user');
+        $collection_id = $this->create('collection', [
+            'user_id' => $other_user_id,
+            'name' => $collection_name,
+            'is_public' => 1,
+        ]);
+        $link_id = $this->create('link', [
+            'user_id' => $other_user_id,
+            'is_hidden' => 0,
+        ]);
+        $this->create('link_to_collection', [
+            'collection_id' => $collection_id,
+            'link_id' => $link_id,
+        ]);
+
+        $response = $this->appRun('get', '/collections/discover', [
+            'page' => 0,
+        ]);
+
+        $this->assertResponse($response, 302, '/collections/discover?page=1');
+    }
+
     public function testDiscoverRedirectsIfNotConnected()
     {
         $collection_name = $this->fake('sentence');

--- a/tests/utils/PaginationTest.php
+++ b/tests/utils/PaginationTest.php
@@ -4,6 +4,30 @@ namespace flusio\utils;
 
 class PaginationTest extends \PHPUnit\Framework\TestCase
 {
+    public function testTotalPage()
+    {
+        $number_elements = 300;
+        $number_per_page = 30;
+        $initial_current_page = 3;
+        $pagination = new Pagination($number_elements, $number_per_page, $initial_current_page);
+
+        $total_pages = $pagination->totalPages();
+
+        $this->assertSame(10, $total_pages);
+    }
+
+    public function testTotalPageIsBoundedBy1()
+    {
+        $number_elements = 0;
+        $number_per_page = 30;
+        $initial_current_page = 1;
+        $pagination = new Pagination($number_elements, $number_per_page, $initial_current_page);
+
+        $total_pages = $pagination->totalPages();
+
+        $this->assertSame(1, $total_pages);
+    }
+
     public function testCurrentPage()
     {
         $number_elements = 300;


### PR DESCRIPTION
Changes proposed in this pull request:

- Set pagination total page minimum to 1

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
