### PR TITLE
imp: Use Pocket time_added as created_at

### DIFF
--- a/src/jobs/Importator.php
+++ b/src/jobs/Importator.php
@@ -199,7 +199,17 @@ class Importator extends Job
                 // In normal cases, created_at is set on save() call. Since we
                 // add links via the bulkInsert call, we have to set created_at
                 // first, or it would fail because of the not-null constraint.
-                $link->created_at = \Minz\Time::now();
+                // If time_added is set (not documented), we use it to set the
+                // property in order to keep the order from Pocket. It defaults
+                // to "now".
+                $created_at = \Minz\Time::now();
+                if (isset($item['time_added'])) {
+                    $timestamp = intval($item['time_added']);
+                    if ($timestamp > 0) {
+                        $created_at->setTimestamp($timestamp);
+                    }
+                }
+                $link->created_at = $created_at;
 
                 // Then, add the link properties values to the list
                 $db_link = $link->toValues();

--- a/tests/jobs/ImportatorTest.php
+++ b/tests/jobs/ImportatorTest.php
@@ -306,6 +306,38 @@ class ImportatorTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull($db_links_to_collection2);
     }
 
+    public function testImportPocketItemsUsesTimeAddedIfItExists()
+    {
+        $importator = new Importator();
+        $user_id = $this->create('user');
+        $user = models\User::find($user_id);
+        $bookmarks_id = $this->create('collection', [
+            'type' => 'bookmarks',
+            'user_id' => $user->id,
+        ]);
+        $url = $this->fake('url');
+        $time_added = $this->fake('dateTime');
+        $items = [
+            [
+                'given_url' => $url,
+                'resolved_url' => $url,
+                'favorite' => '0',
+                'status' => '0',
+                'time_added' => $time_added->getTimestamp(),
+            ],
+        ];
+        $options = [
+            'ignore_tags' => true,
+            'import_bookmarks' => true,
+            'import_favorites' => true,
+        ];
+
+        $importator->importPocketItems($user, $items, $options);
+
+        $link = models\Link::findBy(['url' => $url]);
+        $this->assertSame($time_added->getTimestamp(), $link->created_at->getTimestamp());
+    }
+
     public function testImportPocketItemsDoesNotDuplicateAGivenUrlAlreadyThere()
     {
         $importator = new Importator();


### PR DESCRIPTION
Changes proposed in this pull request:

- Parse time_added and use it as default created_at during Pocket importation

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written
- [x] French locale is synchronized
- [x] commit messages are clear
- [x] documentation is updated (including migration notes)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
