### PR TITLE
tec: Initialize .env file on make start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ else
 endif
 
 .PHONY: start
-start: ## Start a development server (use Docker)
+start: .env ## Start a development server (use Docker)
 	@echo "Running webserver on http://localhost:8000"
 	docker-compose -p flusio -f docker/docker-compose.yml up
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Add `.env` target dependency on `make start`

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] new tests are written N/A
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
