### PR TITLE
imp: Facilitate password managers operations

### DIFF
--- a/src/Routes.php
+++ b/src/Routes.php
@@ -18,6 +18,7 @@ class Routes
         $router->addRoute('get', '/', 'Pages#home', 'home');
         $router->addRoute('get', '/terms', 'Pages#terms', 'terms');
         $router->addRoute('get', '/app.webmanifest', 'Pages#webmanifest', 'webmanifest');
+        $router->addRoute('get', '/.well-known/change-password', 'WellKnown#changePassword');
 
         // Registration
         $router->addRoute('get', '/registration', 'Registrations#new', 'registration');

--- a/src/WellKnown.php
+++ b/src/WellKnown.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace flusio;
+
+use Minz\Response;
+
+/**
+ * @author  Marien Fressinaud <dev@marienfressinaud.fr>
+ * @license http://www.gnu.org/licenses/agpl-3.0.en.html AGPL
+ */
+class WellKnown
+{
+    /**
+     * Redirect to the change password page
+     *
+     * @see https://w3c.github.io/webappsec-change-password-url/
+     *
+     * @response 302 /my/security
+     *
+     * @return \Minz\Response
+     */
+    public function changePassword()
+    {
+        return Response::redirect('security');
+    }
+}

--- a/src/views/my/security/show_confirmed.phtml
+++ b/src/views/my/security/show_confirmed.phtml
@@ -48,7 +48,7 @@
         </div>
 
         <div class="form-group <?= isset($errors['password_hash']) ? 'form-group--invalid' : '' ?>">
-            <label for="password">
+            <label for="new-password">
                 <?= _('New password') ?>
             </label>
 
@@ -58,10 +58,11 @@
 
             <div class="form-group__stack" data-controller="input-password">
                 <input
-                    id="password"
+                    id="new-password"
                     name="password"
                     type="password"
                     data-target="input-password.input"
+                    autocomplete="new-password"
                 />
 
                 <button

--- a/src/views/my/security/show_to_confirm.phtml
+++ b/src/views/my/security/show_to_confirm.phtml
@@ -24,17 +24,18 @@
         <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
 
         <div class="form-group <?= isset($errors['password_hash']) ? 'form-group--invalid' : '' ?>">
-            <label for="password">
+            <label for="current-password">
                 <?= _('Your current password') ?>
             </label>
 
             <div class="form-group__stack" data-controller="input-password">
                 <input
-                    id="password"
+                    id="current-password"
                     name="password"
                     type="password"
                     required
                     data-target="input-password.input"
+                    autocomplete="current-password"
                 />
 
                 <button

--- a/src/views/registrations/new.phtml
+++ b/src/views/registrations/new.phtml
@@ -70,7 +70,7 @@
         </div>
 
         <div class="form-group <?= isset($errors['password_hash']) ? 'form-group--invalid' : '' ?>">
-            <label for="password">
+            <label for="new-password">
                 <?= _('And a password') ?>
             </label>
 
@@ -80,12 +80,13 @@
 
             <div class="form-group__stack" data-controller="input-password">
                 <input
-                    id="password"
+                    id="new-password"
                     name="password"
                     type="password"
                     value="<?= $password ?>"
                     required
                     data-target="input-password.input"
+                    autocomplete="new-password"
                 />
 
                 <button

--- a/src/views/sessions/new.phtml
+++ b/src/views/sessions/new.phtml
@@ -38,6 +38,7 @@
                 value="<?= $email ?>"
                 required
                 autofocus
+                autocomplete="username"
             />
 
             <?php if (isset($errors['email'])): ?>
@@ -48,18 +49,19 @@
         </div>
 
         <div class="form-group <?= isset($errors['password_hash']) ? 'form-group--invalid' : '' ?>">
-            <label for="password">
+            <label for="current-password">
                 <?= _('Password') ?>
             </label>
 
             <div class="form-group__stack" data-controller="input-password">
                 <input
-                    id="password"
+                    id="current-password"
                     name="password"
                     type="password"
                     value="<?= $password ?>"
                     required
                     data-target="input-password.input"
+                    autocomplete="current-password"
                 />
 
                 <button

--- a/tests/WellKnownTest.php
+++ b/tests/WellKnownTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace flusio;
+
+class WellKnownTest extends \PHPUnit\Framework\TestCase
+{
+    use \Minz\Tests\ApplicationHelper;
+    use \Minz\Tests\ResponseAsserts;
+
+    public function testChangePasswordRedirectsToSecurity()
+    {
+        $response = $this->appRun('GET', '/.well-known/change-password');
+
+        $this->assertResponse($response, 302, '/my/security');
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a `/.well-known/change-password` endpoint
- Adapt id and autocomplete attributes on password inputs

References:

- https://w3c.github.io/webappsec-change-password-url/
- https://web.dev/change-password-url/
- https://web.dev/sign-in-form-best-practices

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
