### PR TITLE
tec: Load registration CSRF token with JavaScript

### DIFF
--- a/src/assets/javascripts/application.js
+++ b/src/assets/javascripts/application.js
@@ -13,6 +13,7 @@ import ModalController from 'js/controllers/modal_controller.js';
 import ModalOpenerController from 'js/controllers/modal_opener_controller.js';
 import PocketOptionController from 'js/controllers/pocket_option_controller.js';
 import PopupController from 'js/controllers/popup_controller.js';
+import RegistrationFormController from 'js/controllers/registration_form_controller.js';
 import SkipNavController from 'js/controllers/skip_nav_controller.js';
 
 window.jsConfiguration = JSON.parse(document.getElementById('javascript-configuration').innerHTML);
@@ -32,6 +33,7 @@ application.register('modal', ModalController);
 application.register('modal-opener', ModalOpenerController);
 application.register('pocket-option', PocketOptionController);
 application.register('popup', PopupController);
+application.register('registration-form', RegistrationFormController);
 application.register('skip-nav', SkipNavController);
 
 function adaptLayoutContentBorderRadius () {

--- a/src/assets/javascripts/controllers/registration_form_controller.js
+++ b/src/assets/javascripts/controllers/registration_form_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+    connect () {
+        // We add the csrf token with JavaScript to hopefully block bots which
+        // spam registration. Since JS is required to use flusio, it should be
+        // transparent for users.
+        const csrfName = document.querySelector('meta[name="csrf-param"]').content;
+        const csrfValue = document.querySelector('meta[name="csrf-token"]').content;
+        const csrfInput = document.createElement('input');
+        csrfInput.setAttribute('type', 'hidden');
+        csrfInput.setAttribute('name', csrfName);
+        csrfInput.setAttribute('value', csrfValue);
+        this.element.appendChild(csrfInput);
+    }
+};

--- a/src/views/_layouts/connected.phtml
+++ b/src/views/_layouts/connected.phtml
@@ -35,6 +35,9 @@
         </script>
         <script src="<?= url_asset('javascripts/application.js') ?>" data-turbolinks-track="reload" defer></script>
 
+        <meta name="csrf-param" content="csrf" />
+        <meta name="csrf-token" content="<?= csrf_token() ?>" />
+
         <title><?php if ($environment === 'development'): ?>[devmode] <?php endif; ?><?= $title ?></title>
     </head>
 

--- a/src/views/_layouts/connected_blocked.phtml
+++ b/src/views/_layouts/connected_blocked.phtml
@@ -31,6 +31,9 @@
         </script>
         <script src="<?= url_asset('javascripts/application.js') ?>" data-turbolinks-track="reload" defer></script>
 
+        <meta name="csrf-param" content="csrf" />
+        <meta name="csrf-token" content="<?= csrf_token() ?>" />
+
         <title><?php if ($environment === 'development'): ?>[devmode] <?php endif; ?><?= $title ?></title>
     </head>
 

--- a/src/views/_layouts/not_connected.phtml
+++ b/src/views/_layouts/not_connected.phtml
@@ -47,6 +47,9 @@
         </script>
         <script src="<?= url_asset('javascripts/application.js') ?>" data-turbolinks-track="reload" defer></script>
 
+        <meta name="csrf-param" content="csrf" />
+        <meta name="csrf-token" content="<?= csrf_token() ?>" />
+
         <title><?php if ($environment === 'development'): ?>[devmode] <?php endif; ?><?= $title ?> · <?= $brand ?></title>
     </head>
 

--- a/src/views/_layouts/onboarding.phtml
+++ b/src/views/_layouts/onboarding.phtml
@@ -24,6 +24,9 @@
         </script>
         <script src="<?= url_asset('javascripts/application.js') ?>" data-turbolinks-track="reload" defer></script>
 
+        <meta name="csrf-param" content="csrf" />
+        <meta name="csrf-token" content="<?= csrf_token() ?>" />
+
         <title><?php if ($environment === 'development'): ?>[devmode] <?php endif; ?><?= $title ?></title>
     </head>
 

--- a/src/views/registrations/new.phtml
+++ b/src/views/registrations/new.phtml
@@ -10,14 +10,12 @@
         <h1><?= _('Sign up') ?></h1>
     </div>
 
-    <form method="post" action="<?= url('create user') ?>">
+    <form method="post" action="<?= url('create user') ?>" data-controller="registration-form">
         <?php if ($error): ?>
             <p class="form__error">
                 <?= $error ?>
             </p>
         <?php endif; ?>
-
-        <input type="hidden" name="csrf" value="<?= csrf_token() ?>" />
 
         <div class="form-group <?= isset($errors['username']) ? 'form-group--invalid' : '' ?>">
             <label for="username">


### PR DESCRIPTION
Changes proposed in this pull request:

- Add csrf token as meta tag in html head
- Remove HTML csrf input from registration form
- Add a JS controller to load the csrf token from meta to the the form

A lot of accounts have been created by bots lately. Hopefully, they
don’t run JavaScript and they will not be able to submit the form
anymore.

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written N/A
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
