### PR TITLE
tec: Clear job errors on reschedule

### DIFF
--- a/src/models/dao/Job.php
+++ b/src/models/dao/Job.php
@@ -104,6 +104,8 @@ class Job extends \Minz\DatabaseModel
         }
         $this->update($db_job['id'], [
             'locked_at' => null,
+            'last_error' => null,
+            'failed_at' => null,
             'perform_at' => $perform_at->format(\Minz\Model::DATETIME_FORMAT),
         ]);
     }


### PR DESCRIPTION
Changes proposed in this pull request:

- Set `last_error` and `failed_at` to null on reschedule
- Calculate correct `perform_at` when scheduling job on error

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] new tests are written
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
