### PR TITLE
Imp/full atom link

### DIFF
--- a/src/views/_layouts/connected.phtml
+++ b/src/views/_layouts/connected.phtml
@@ -10,7 +10,7 @@
         <?php endif; ?>
 
         <?php if ($feed): ?>
-            <link rel="alternate" type="application/atom+xml" title="<?= $this->protect($feed['title']) ?>" href="<?= $feed['url'] ?>" />
+            <link rel="alternate" type="application/atom+xml" title="<?= protect($feed['title']) ?>" href="<?= $feed['url'] ?>" />
         <?php endif; ?>
 
         <meta name="application-name" content="<?= $brand ?>">
@@ -128,7 +128,7 @@
                         </summary>
 
                         <nav class="popup__container popup__container--left">
-                            <div class="popup__title"><?= $this->protect($current_user->username) ?></div>
+                            <div class="popup__title"><?= protect($current_user->username) ?></div>
 
                             <a
                                 class="popup__item popup__item--link icon icon--avatar"

--- a/src/views/_layouts/connected_blocked.phtml
+++ b/src/views/_layouts/connected_blocked.phtml
@@ -101,7 +101,7 @@
                         </summary>
 
                         <nav class="popup__container popup__container--left">
-                            <div class="popup__title"><?= $this->protect($current_user->username) ?></div>
+                            <div class="popup__title"><?= protect($current_user->username) ?></div>
 
                             <a
                                 class="popup__item popup__item--link icon icon--avatar"

--- a/src/views/_layouts/not_connected.phtml
+++ b/src/views/_layouts/not_connected.phtml
@@ -10,13 +10,13 @@
         <?php endif; ?>
 
         <?php if ($feed): ?>
-            <link rel="alternate" type="application/atom+xml" title="<?= $this->protect($feed['title']) ?>" href="<?= $feed['url'] ?>" />
+            <link rel="alternate" type="application/atom+xml" title="<?= protect($feed['title']) ?>" href="<?= $feed['url'] ?>" />
         <?php endif; ?>
 
         <?php if ($open_graph): ?>
-            <meta property="og:title" content="<?= $this->protect($open_graph['title']) ?>" />
+            <meta property="og:title" content="<?= protect($open_graph['title']) ?>" />
             <meta property="og:type" content="website" />
-            <meta property="og:description" content="<?= $this->protect($open_graph['description']) ?>" />
+            <meta property="og:description" content="<?= protect($open_graph['description']) ?>" />
             <meta property="og:locale" content="<?= $open_graph['locale'] ?>" />
             <meta property="og:url" content="<?= $open_graph['url'] ?>" />
             <meta name="twitter:card" content="summary">

--- a/src/views/collections/discover.phtml
+++ b/src/views/collections/discover.phtml
@@ -25,7 +25,7 @@
                     <div class="card__body">
                         <h2 class="card__title">
                             <a class="anchor--hidden" href="<?= url('collection', ['id' => $collection->id]) ?>" tabindex="-1">
-                                <?= $this->protect($collection->name) ?>
+                                <?= protect($collection->name) ?>
                             </a>
                         </h2>
 
@@ -36,7 +36,7 @@
                                 <?= _nf('%d link', '%d links', $collection->number_links, $collection->number_links) ?>
                             <?php endif; ?>
 
-                            · <?= _f('created by %s', $this->protect($collection->owner()->username)) ?>
+                            · <?= _f('created by %s', protect($collection->owner()->username)) ?>
 
                             <?php if ($current_user->isFollowing($collection->id)): ?>
                                 <span class="sticker sticker--right"><?= _('followed') ?></span>

--- a/src/views/collections/edit.phtml
+++ b/src/views/collections/edit.phtml
@@ -88,7 +88,7 @@
                             />
 
                             <label class="topics-selector__label" for="topic-<?= $topic->id ?>">
-                                <?= $this->protect($topic->label) ?>
+                                <?= protect($topic->label) ?>
                             </label>
                         </div>
                     <?php endforeach; ?>

--- a/src/views/collections/feed.atom.xml.phtml
+++ b/src/views/collections/feed.atom.xml.phtml
@@ -1,11 +1,11 @@
 <?= '<?xml version="1.0" encoding="UTF-8" ?>' . "\n" ?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-    <title><?= $this->protect($collection->name) ?></title>
+    <title><?= protect($collection->name) ?></title>
     <link href="<?= url_full('collection', ['id' => $collection->id]) ?>" rel="alternate" type="text/html" />
     <link href="<?= url_full('collection feed', ['id' => $collection->id]) ?>" rel="self" type="application/atom+xml" />
     <id><?= $collection->tagUri() ?></id>
     <author>
-        <name><?= $this->protect($collection->owner()->username) ?></name>
+        <name><?= protect($collection->owner()->username) ?></name>
     </author>
     <generator><?= $user_agent ?></generator>
     <?php if (isset($links[0])): ?>
@@ -15,20 +15,20 @@
     <?php endif; ?>
 
     <?php foreach ($topics as $topic): ?>
-        <category term="<?= $this->protect($topic->label) ?>"></category>
+        <category term="<?= protect($topic->label) ?>"></category>
     <?php endforeach; ?>
 
     <?php foreach ($links as $link): ?>
         <entry>
-            <title><?= $this->protect($link->title) ?></title>
+            <title><?= protect($link->title) ?></title>
             <id><?= $link->tagUri() ?></id>
-            <link href="<?= $link->url ?>" rel="alternate" type="text/html" />
+            <link href="<?= protect($link->url) ?>" rel="alternate" type="text/html" />
             <link href="<?= url_full('link', ['id' => $link->id]) ?>" rel="replies" type="text/html" />
             <published><?= $link->created_at->format(\DateTimeInterface::ATOM) ?></published>
             <updated><?= $link->created_at->format(\DateTimeInterface::ATOM) ?></updated>
             <content type="html"><![CDATA[
-                <p><?= _f('“%s”', $this->protect($link->title)) ?></p>
-                <p><?= _f('Read this on <a href="%s">%s</a>.', $link->url, $this->protect($link->host())) ?></p>
+                <p><?= _f('“%s”', protect($link->title)) ?></p>
+                <p><?= _f('Read this on <a href="%s">%s</a>.', protect($link->url), protect($link->host())) ?></p>
                 <p><?= _f('My comments on <a href="%s">%s</a>.', url_full('link', ['id' => $link->id]), $brand) ?></p>
             ]]></content>
         </entry>

--- a/src/views/collections/index.phtml
+++ b/src/views/collections/index.phtml
@@ -35,7 +35,7 @@
                 <div class="card__body">
                     <h2 class="card__title">
                         <a class="anchor--hidden" href="<?= url('collection', ['id' => $collection->id]) ?>" tabindex="-1">
-                            <?= $this->protect($collection->name) ?>
+                            <?= protect($collection->name) ?>
                         </a>
                     </h2>
 
@@ -86,7 +86,7 @@
                     <div class="card__body">
                         <h2 class="card__title">
                             <a class="anchor--hidden" href="<?= url('collection', ['id' => $collection->id]) ?>" tabindex="-1">
-                                <?= $this->protect($collection->name) ?>
+                                <?= protect($collection->name) ?>
                             </a>
                         </h2>
 
@@ -97,7 +97,7 @@
                                 <?= _nf('%d link', '%d links', $collection->number_links, $collection->number_links) ?>
                             <?php endif; ?>
 
-                            · <?= _f('created by %s', $this->protect($collection->owner()->username)) ?>
+                            · <?= _f('created by %s', protect($collection->owner()->username)) ?>
                         </p>
                     </div>
 

--- a/src/views/collections/new.phtml
+++ b/src/views/collections/new.phtml
@@ -87,7 +87,7 @@
                             />
 
                             <label class="topics-selector__label" for="topic-<?= $topic->id ?>">
-                                <?= $this->protect($topic->label) ?>
+                                <?= protect($topic->label) ?>
                             </label>
                         </div>
                     <?php endforeach; ?>

--- a/src/views/collections/show.phtml
+++ b/src/views/collections/show.phtml
@@ -16,7 +16,7 @@
 
 <div class="section" data-controller="back-storage" data-back-storage-type="link">
     <div class="section__title">
-        <h1><?= $this->protect($collection->name) ?></h1>
+        <h1><?= protect($collection->name) ?></h1>
     </div>
 
     <?php if ($topics): ?>
@@ -53,7 +53,7 @@
     </div>
 
     <p class="collection__description">
-        <?= nl2br($this->protect($collection->description)) ?>
+        <?= nl2br(protect($collection->description)) ?>
     </p>
 
     <div class="cards">
@@ -78,7 +78,7 @@
                     target="_blank"
                     rel="noopener noreferrer"
                     tabindex="-1"
-                    href="<?= $link->url ?>"
+                    href="<?= protect($link->url) ?>"
                 >
                     <img class="card__image" alt="" src="<?= url_link_image('cards', $link->image_filename) ?>" />
                 </a>
@@ -90,14 +90,14 @@
                             target="_blank"
                             rel="noopener noreferrer"
                             tabindex="-1"
-                            href="<?= $link->url ?>"
+                            href="<?= protect($link->url) ?>"
                         >
-                            <?= $this->protect($link->title) ?>
+                            <?= protect($link->title) ?>
                         </a>
                     </h2>
 
                     <p class="card__text card__text--oneline">
-                        <span class="card__ellipsis"><?= $this->protect($link->host()) ?></span>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>
+                        <span class="card__ellipsis"><?= protect($link->host()) ?></span>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>
                     </p>
 
                     <p class="card__text">
@@ -142,7 +142,7 @@
                                 </button>
 
                                 <div data-controller="copy-to-clipboard">
-                                    <input type="hidden" value="<?= $link->url ?>" data-target="copy-to-clipboard.copyable" />
+                                    <input type="hidden" value="<?= protect($link->url) ?>" data-target="copy-to-clipboard.copyable" />
 
                                     <button
                                         class="popup__item popup__item--button share__button icon icon--copy-to-clipboard"
@@ -175,7 +175,7 @@
                         class="anchor--action icon icon--anchor icon--pop-out"
                         target="_blank"
                         rel="noopener noreferrer"
-                        href="<?= $link->url ?>"
+                        href="<?= protect($link->url) ?>"
                     >
                         <?= _('read') ?>
                     </a>

--- a/src/views/collections/show.phtml
+++ b/src/views/collections/show.phtml
@@ -4,7 +4,7 @@
         'canonical' => url('collection', ['id' => $collection->id]),
         'current_tab' => 'collections',
         'feed' => [
-            'url' => url('collection feed', ['id' => $collection->id]),
+            'url' => url_full('collection feed', ['id' => $collection->id]),
             'title' => _f('Syndication feed of %s', $collection->name),
         ],
         'back' => [

--- a/src/views/collections/show_bookmarks.phtml
+++ b/src/views/collections/show_bookmarks.phtml
@@ -8,7 +8,7 @@
 
 <div class="section" data-controller="back-storage" data-back-storage-type="link">
     <div class="section__title">
-        <h1><?= $this->protect($collection->name()) ?></h1>
+        <h1><?= protect($collection->name()) ?></h1>
     </div>
 
     <p class="section__intro">
@@ -37,7 +37,7 @@
                     target="_blank"
                     rel="noopener noreferrer"
                     tabindex="-1"
-                    href="<?= $link->url ?>"
+                    href="<?= protect($link->url) ?>"
                 >
                     <img class="card__image" alt="" src="<?= url_link_image('cards', $link->image_filename) ?>" />
                 </a>
@@ -49,14 +49,14 @@
                             target="_blank"
                             rel="noopener noreferrer"
                             tabindex="-1"
-                            href="<?= $link->url ?>"
+                            href="<?= protect($link->url) ?>"
                         >
-                            <?= $this->protect($link->title) ?>
+                            <?= protect($link->title) ?>
                         </a>
                     </h2>
 
                     <p class="card__text card__text--oneline">
-                        <span class="card__ellipsis"><?= $this->protect($link->host()) ?></span>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>
+                        <span class="card__ellipsis"><?= protect($link->host()) ?></span>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>
                     </p>
 
                     <p class="card__text">
@@ -95,7 +95,7 @@
                                 </button>
 
                                 <div data-controller="copy-to-clipboard">
-                                    <input type="hidden" value="<?= $link->url ?>" data-target="copy-to-clipboard.copyable" />
+                                    <input type="hidden" value="<?= protect($link->url) ?>" data-target="copy-to-clipboard.copyable" />
 
                                     <button
                                         class="popup__item popup__item--button share__button icon icon--copy-to-clipboard"
@@ -137,7 +137,7 @@
                         class="anchor--action icon icon--anchor icon--pop-out"
                         target="_blank"
                         rel="noopener noreferrer"
-                        href="<?= $link->url ?>"
+                        href="<?= protect($link->url) ?>"
                     >
                         <?= _('read') ?>
                     </a>

--- a/src/views/collections/show_public.phtml
+++ b/src/views/collections/show_public.phtml
@@ -27,7 +27,7 @@
 
 <div class="section" data-controller="back-storage" data-back-storage-type="link">
     <div class="section__title">
-        <h1><?= $this->protect($collection->name) ?></h1>
+        <h1><?= protect($collection->name) ?></h1>
     </div>
 
     <?php if ($error): ?>
@@ -45,7 +45,7 @@
     <div class="collection__meta">
         <div class="collection__details">
             <p class="collection__owner">
-                <?= _f('created by %s', $this->protect($owner->username)) ?>
+                <?= _f('created by %s', protect($owner->username)) ?>
             </p>
         </div>
 
@@ -71,7 +71,7 @@
     </div>
 
     <p class="collection__description">
-        <?= nl2br($this->protect($collection->description)) ?>
+        <?= nl2br(protect($collection->description)) ?>
     </p>
 
     <?php if ($links): ?>
@@ -83,7 +83,7 @@
                         target="_blank"
                         rel="noopener noreferrer"
                         tabindex="-1"
-                        href="<?= $link->url ?>"
+                        href="<?= protect($link->url) ?>"
                     >
                         <img class="card__image" alt="" src="<?= url_link_image('cards', $link->image_filename) ?>" />
                     </a>
@@ -95,14 +95,14 @@
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 tabindex="-1"
-                                href="<?= $link->url ?>"
+                                href="<?= protect($link->url) ?>"
                             >
-                                <?= $this->protect($link->title) ?>
+                                <?= protect($link->title) ?>
                             </a>
                         </h2>
 
                         <p class="card__text card__text--oneline">
-                            <span class="card__ellipsis"><?= $this->protect($link->host()) ?></span>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>
+                            <span class="card__ellipsis"><?= protect($link->host()) ?></span>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>
                         </p>
 
                         <p class="card__text">
@@ -119,7 +119,7 @@
                             class="anchor--action icon icon--anchor icon--pop-out"
                             target="_blank"
                             rel="noopener noreferrer"
-                            href="<?= $link->url ?>"
+                            href="<?= protect($link->url) ?>"
                         >
                             <?= _('read') ?>
                         </a>

--- a/src/views/collections/show_public.phtml
+++ b/src/views/collections/show_public.phtml
@@ -12,7 +12,7 @@
         'canonical' => url('collection', ['id' => $collection->id]),
         'current_tab' => 'collections',
         'feed' => [
-            'url' => url('collection feed', ['id' => $collection->id]),
+            'url' => url_full('collection feed', ['id' => $collection->id]),
             'title' => _f('Syndication feed of %s', $collection->name),
         ],
         'open_graph' => $open_graph,

--- a/src/views/importations/pocket/show.phtml
+++ b/src/views/importations/pocket/show.phtml
@@ -63,7 +63,7 @@
         </p>
 
         <p class="paragraph--centered">
-            <?= $this->protect($importation->error) ?>
+            <?= protect($importation->error) ?>
         </p>
 
         <form method="post" action="<?= url('delete importation', ['id' => $importation->id]) ?>">
@@ -164,7 +164,7 @@
 
         <p class="paragraph--centered paragraph--secondary">
             <small>
-                <?= _f('connected with account <em>%s</em>', $this->protect($current_user->pocket_username)) ?>
+                <?= _f('connected with account <em>%s</em>', protect($current_user->pocket_username)) ?>
             </small>
         </p>
     <?php else: ?>

--- a/src/views/link_collections/index.phtml
+++ b/src/views/link_collections/index.phtml
@@ -15,7 +15,7 @@
     </div>
 
     <p class="section__intro">
-        <?= $this->protect($link->title) ?>
+        <?= protect($link->title) ?>
     </p>
 
     <form method="post" action="<?= url('update link collections', ['id' => $link->id]) ?>">
@@ -43,7 +43,7 @@
                 >
                     <?php foreach ($collections as $collection): ?>
                         <option <?= in_array($collection->id, $collection_ids) ? 'selected' : '' ?> value="<?= $collection->id ?>">
-                            <?= $this->protect($collection->name()) ?>
+                            <?= protect($collection->name()) ?>
                         </option>
                     <?php endforeach; ?>
                 </select>

--- a/src/views/links/edit.phtml
+++ b/src/views/links/edit.phtml
@@ -15,7 +15,7 @@
     </div>
 
     <p class="section__intro">
-        <?= $this->protect($link->title) ?>
+        <?= protect($link->title) ?>
     </p>
 
     <form method="post" action="<?= url('update link', ['id' => $link->id]) ?>">

--- a/src/views/links/feed.atom.xml.phtml
+++ b/src/views/links/feed.atom.xml.phtml
@@ -1,11 +1,11 @@
 <?= '<?xml version="1.0" encoding="UTF-8" ?>' . "\n" ?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-    <title><?= _f('Comments on %s', $this->protect($link->title)) ?></title>
+    <title><?= _f('Comments on %s', protect($link->title)) ?></title>
     <link href="<?= url_full('link', ['id' => $link->id]) ?>" rel="alternate" type="text/html" />
     <link href="<?= url_full('link feed', ['id' => $link->id]) ?>" rel="self" type="application/atom+xml" />
     <id><?= $link->tagUri() ?></id>
     <author>
-        <name><?= $this->protect($link->owner()->username) ?></name>
+        <name><?= protect($link->owner()->username) ?></name>
     </author>
     <generator><?= $user_agent ?></generator>
     <?php if (isset($messages[0])): ?>
@@ -16,13 +16,13 @@
 
     <?php foreach ($messages as $message): ?>
         <entry>
-            <title><?= _f('Comment by %s', $this->protect($message->user()->username)) ?></title>
+            <title><?= _f('Comment by %s', protect($message->user()->username)) ?></title>
             <id><?= $message->tagUri() ?></id>
             <link href="<?= url_full('link', ['id' => $link->id]) ?>#message-<?= $message->id ?>" rel="alternate" type="text/html" />
             <published><?= $message->created_at->format(\DateTimeInterface::ATOM) ?></published>
             <updated><?= $message->created_at->format(\DateTimeInterface::ATOM) ?></updated>
             <content type="html"><![CDATA[
-                <p><?= nl2br($this->protect($message->content)) ?></p>
+                <p><?= nl2br(protect($message->content)) ?></p>
             ]]></content>
         </entry>
     <?php endforeach; ?>

--- a/src/views/links/new.phtml
+++ b/src/views/links/new.phtml
@@ -71,7 +71,7 @@
                 >
                     <?php foreach ($collections as $collection): ?>
                         <option <?= in_array($collection->id, $collection_ids) ? 'selected' : '' ?> value="<?= $collection->id ?>">
-                            <?= $this->protect($collection->name()) ?>
+                            <?= protect($collection->name()) ?>
                         </option>
                     <?php endforeach; ?>
                 </select>

--- a/src/views/links/show.phtml
+++ b/src/views/links/show.phtml
@@ -3,7 +3,7 @@
         'title' => $link->title,
         'canonical' => url_full('link', ['id' => $link->id]),
         'feed' => [
-            'url' => url('link feed', ['id' => $link->id]),
+            'url' => url_full('link feed', ['id' => $link->id]),
             'title' => _f('Syndication feed of comments on %s', $link->title),
         ],
         'back' => [

--- a/src/views/links/show.phtml
+++ b/src/views/links/show.phtml
@@ -24,12 +24,12 @@
     <?php endif; ?>
 
     <div class="section__title">
-        <h1><?= $this->protect($link->title) ?></h1>
+        <h1><?= protect($link->title) ?></h1>
     </div>
 
     <section class="link__meta">
         <p class="link__details">
-            <?= $this->protect($link->host()) ?>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>
+            <?= protect($link->host()) ?>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>
         </p>
 
         <ul class="link__actions">
@@ -38,7 +38,7 @@
                     class="anchor--action icon icon--anchor icon--pop-out"
                     target="_blank"
                     rel="noopener noreferrer"
-                    href="<?= $link->url ?>"
+                    href="<?= protect($link->url) ?>"
                 >
                     <?= _('read') ?>
                 </a>
@@ -55,7 +55,7 @@
                         <img class="message__avatar" src="<?= url_avatar($user->avatar_filename) ?>" alt="" />
 
                         <div class="message__author">
-                            <?= $this->protect($user->username) ?>
+                            <?= protect($user->username) ?>
                         </div>
 
                         <div class="header__separator"></div>
@@ -99,7 +99,7 @@
                 </header>
 
                 <div class="message__content">
-                    <?= nl2br($this->protect($message->content)) ?>
+                    <?= nl2br(protect($message->content)) ?>
                 </div>
             </article>
         <?php endforeach; ?>

--- a/src/views/links/show_fetch.phtml
+++ b/src/views/links/show_fetch.phtml
@@ -11,12 +11,12 @@
     </div>
 
     <p class="section__intro">
-        <?= $this->protect($link->url) ?>
+        <?= protect($link->url) ?>
     </p>
 
     <?php if ($link->fetched_at): ?>
         <p class="paragraph--featured">
-            <?= _f('The link title will be “<em>%s</em>”.', $this->protect($link->title)) ?>
+            <?= _f('The link title will be “<em>%s</em>”.', protect($link->title)) ?>
         </p>
 
         <p class="paragraph--centered">

--- a/src/views/links/show_public.phtml
+++ b/src/views/links/show_public.phtml
@@ -14,7 +14,7 @@
         'title' => $link->title,
         'canonical' => url_full('link', ['id' => $link->id]),
         'feed' => [
-            'url' => url('link feed', ['id' => $link->id]),
+            'url' => url_full('link feed', ['id' => $link->id]),
             'title' => _f('Syndication feed of comments on %s', $link->title),
         ],
         'open_graph' => $open_graph,

--- a/src/views/links/show_public.phtml
+++ b/src/views/links/show_public.phtml
@@ -37,12 +37,12 @@
     <?php endif; ?>
 
     <div class="section__title">
-        <h1><?= $this->protect($link->title) ?></h1>
+        <h1><?= protect($link->title) ?></h1>
     </div>
 
     <section class="link__meta">
         <p class="link__details">
-            <?= $this->protect($link->host()) ?>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>
+            <?= protect($link->host()) ?>&nbsp;·&nbsp;<?= format_reading_time($link->reading_time) ?>
         </p>
 
         <ul class="link__actions">
@@ -51,7 +51,7 @@
                     class="anchor--action icon icon--anchor icon--pop-out"
                     target="_blank"
                     rel="noopener noreferrer"
-                    href="<?= $link->url ?>"
+                    href="<?= protect($link->url) ?>"
                 >
                     <?= _('read') ?>
                 </a>
@@ -69,7 +69,7 @@
                             <img class="message__avatar" src="<?= url_avatar($user->avatar_filename) ?>" alt="" />
 
                             <div class="message__author">
-                                <?= $this->protect($user->username) ?>
+                                <?= protect($user->username) ?>
                             </div>
 
                             <div class="header__separator"></div>
@@ -81,14 +81,14 @@
                     </header>
 
                     <div class="message__content">
-                        <?= nl2br($this->protect($message->content)) ?>
+                        <?= nl2br(protect($message->content)) ?>
                     </div>
                 </article>
             <?php endforeach; ?>
         </section>
     <?php else: ?>
         <p class="paragraph--placeholder">
-            <?= _f('%s didn’t comment on this link.', $this->protect($owner->username)) ?>
+            <?= _f('%s didn’t comment on this link.', protect($owner->username)) ?>
         </p>
     <?php endif; ?>
 </div>

--- a/src/views/my/profile/show.phtml
+++ b/src/views/my/profile/show.phtml
@@ -109,7 +109,7 @@
                             />
 
                             <label class="topics-selector__label" for="topic-<?= $topic->id ?>">
-                                <?= $this->protect($topic->label) ?>
+                                <?= protect($topic->label) ?>
                             </label>
                         </div>
                     <?php endforeach; ?>

--- a/src/views/news_link_removals/adding.phtml
+++ b/src/views/news_link_removals/adding.phtml
@@ -16,7 +16,7 @@
     </div>
 
     <p class="section__intro">
-        <?= $this->protect($news_link->title) ?>
+        <?= protect($news_link->title) ?>
     </p>
 
     <form method="post" action="<?= url('add news', ['id' => $news_link->id]) ?>">
@@ -49,7 +49,7 @@
                 >
                     <?php foreach ($collections as $collection): ?>
                         <option <?= in_array($collection->id, $collection_ids) ? 'selected' : '' ?> value="<?= $collection->id ?>">
-                            <?= $this->protect($collection->name()) ?>
+                            <?= protect($collection->name()) ?>
                         </option>
                     <?php endforeach; ?>
                 </select>

--- a/src/views/news_links/index.phtml
+++ b/src/views/news_links/index.phtml
@@ -41,7 +41,7 @@
                         target="_blank"
                         rel="noopener noreferrer"
                         tabindex="-1"
-                        href="<?= $news_link->url ?>"
+                        href="<?= protect($news_link->url) ?>"
                     >
                         <img class="card__image" alt="" src="<?= url_link_image('cards', $news_link->image_filename) ?>" />
                     </a>
@@ -53,14 +53,14 @@
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 tabindex="-1"
-                                href="<?= $news_link->url ?>"
+                                href="<?= protect($news_link->url) ?>"
                             >
-                                <?= $this->protect($news_link->title) ?>
+                                <?= protect($news_link->title) ?>
                             </a>
                         </h2>
 
                         <p class="card__text card__text--oneline">
-                            <span class="card__ellipsis"><?= $this->protect($news_link->host()) ?></span>&nbsp;·&nbsp;<?= format_reading_time($news_link->reading_time) ?>
+                            <span class="card__ellipsis"><?= protect($news_link->host()) ?></span>&nbsp;·&nbsp;<?= format_reading_time($news_link->reading_time) ?>
                         </p>
 
                         <p class="card__text news__via">
@@ -68,12 +68,12 @@
                                 <?= _('via your <strong>bookmarks</strong>') ?>
                             <?php elseif ($news_link->via_type === 'topics' && $news_link->via_link_id): ?>
                                 <?php $via_link = $news_link->viaLink(); ?>
-                                <?= _f('via your <strong>points of interest</strong>, added by %s', $this->protect($via_link->owner()->username)) ?>
+                                <?= _f('via your <strong>points of interest</strong>, added by %s', protect($via_link->owner()->username)) ?>
                             <?php elseif ($news_link->via_type === 'topics'): ?>
                                 <?= _('via your <strong>points of interest</strong>') ?>
                             <?php elseif ($news_link->via_type === 'followed' && $news_link->via_collection_id): ?>
                                 <?php $via_collection = $news_link->viaCollection(); ?>
-                                <?= _f('via <strong>%s</strong> by %s', $this->protect($via_collection->name()), $this->protect($via_collection->owner()->username)) ?>
+                                <?= _f('via <strong>%s</strong> by %s', protect($via_collection->name()), protect($via_collection->owner()->username)) ?>
                             <?php elseif ($news_link->via_type === 'followed'): ?>
                                 <?= _('via a <strong>followed collection</strong> (now deleted)') ?>
                             <?php endif; ?>
@@ -149,7 +149,7 @@
                             class="anchor--action icon icon--anchor icon--pop-out"
                             target="_blank"
                             rel="noopener noreferrer"
-                            href="<?= $news_link->url ?>"
+                            href="<?= protect($news_link->url) ?>"
                         >
                             <?= _('read') ?>
                         </a>

--- a/src/views/onboarding/step1.phtml
+++ b/src/views/onboarding/step1.phtml
@@ -7,7 +7,7 @@
 
 <div class="section section--small">
     <div class="section__title">
-        <h1><?= _f('Welcome %s!', $this->protect($current_user->username)) ?></h1>
+        <h1><?= _f('Welcome %s!', protect($current_user->username)) ?></h1>
     </div>
 
     <form

--- a/src/views/onboarding/step4.phtml
+++ b/src/views/onboarding/step4.phtml
@@ -84,7 +84,7 @@
                         />
 
                         <label class="topics-selector__label" for="topic-<?= $topic->id ?>">
-                            <?= $this->protect($topic->label) ?>
+                            <?= protect($topic->label) ?>
                         </label>
                     </div>
                 <?php endforeach; ?>


### PR DESCRIPTION
Changes proposed in this pull request:

- Use absolute URLs for atom links
- Add html entities protection on URLs
- Use the `protect()` function from view helpers instead of `$this->protect()` from View

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] new tests are written N/A
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
