### PR TITLE
fix: Adapt number links on owned collections page

### DIFF
--- a/src/controllers/Collections.php
+++ b/src/controllers/Collections.php
@@ -192,7 +192,8 @@ class Collections
 
         $number_links = models\Link::daoCall('countByCollectionId', $collection->id, !$is_owned);
         $pagination_page = intval($request->param('page', 1));
-        $pagination = new utils\Pagination($number_links, 30, $pagination_page);
+        $number_per_page = $is_owned ? 29 : 30; // the button to add a link counts for 1!
+        $pagination = new utils\Pagination($number_links, $number_per_page, $pagination_page);
         if ($pagination_page !== $pagination->currentPage()) {
             return Response::redirect('collection', [
                 'id' => $collection->id,


### PR DESCRIPTION
Changes proposed in this pull request:

- List 29 links on owned collections page instead of 30

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written N/A
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes) N/A

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
