### PR TITLE
imp: Redirect to search on "back" of feeds pages

### DIFF
--- a/src/assets/javascripts/controllers/back_storage_controller.js
+++ b/src/assets/javascripts/controllers/back_storage_controller.js
@@ -2,8 +2,10 @@ import { Controller } from 'stimulus';
 
 export default class extends Controller {
     initialize () {
-        const type = this.data.get('type');
+        const types = this.data.get('type').split(',');
         const currentPath = window.location.pathname + window.location.search;
-        window.localStorage.setItem('back-' + type, currentPath);
+        types.forEach((type) => {
+            window.localStorage.setItem('back-' + type.trim(), currentPath);
+        });
     }
 };

--- a/src/views/links/searches/show.phtml
+++ b/src/views/links/searches/show.phtml
@@ -5,7 +5,7 @@
     ]);
 ?>
 
-<div class="section" data-controller="back-storage" data-back-storage-type="link">
+<div class="section" data-controller="back-storage" data-back-storage-type="link,collection">
     <div class="section__title">
         <h1 id="modal-title"><?= _('New link') ?></h1>
     </div>


### PR DESCRIPTION
Changes proposed in this pull request:

- Allow to pass several types on "back storage" controller
- Save "collection" to search back storage

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written N/A
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
