### PR TITLE
tec: Provide a scheduled job to clean the cache

### DIFF
--- a/lib/SpiderBits/src/Cache.php
+++ b/lib/SpiderBits/src/Cache.php
@@ -89,4 +89,26 @@ class Cache
     {
         return hash('sha256', $string);
     }
+
+    /**
+     * Clean the cache
+     *
+     * @param integer $validity_interval
+     *     How many seconds the cache is valid, default is 7 days
+     */
+    public function clean($validity_interval = 7 * 24 * 60 * 60)
+    {
+        $files = scandir($this->path);
+        foreach ($files as $file) {
+            if ($file === '.' || $file === '..') {
+                continue;
+            }
+
+            $filepath = $this->path . '/' . $file;
+            $mtime = @filemtime($filepath);
+            if ($mtime === false || $mtime <= (time() - $validity_interval)) {
+                @unlink($filepath);
+            }
+        }
+    }
 }

--- a/src/jobs/scheduled/CacheCleaner.php
+++ b/src/jobs/scheduled/CacheCleaner.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace flusio\jobs\scheduled;
+
+use flusio\jobs;
+use flusio\models;
+use flusio\utils;
+
+/**
+ * Job to clean the cache.
+ *
+ * @author  Marien Fressinaud <dev@marienfressinaud.fr>
+ * @license http://www.gnu.org/licenses/agpl-3.0.en.html AGPL
+ */
+class CacheCleaner extends jobs\Job
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->perform_at = \Minz\Time::relative('tomorrow 1:00');
+        $this->frequency = '+1 day';
+    }
+
+    public function perform()
+    {
+        $cache = new \SpiderBits\Cache(\Minz\Configuration::$application['cache_path']);
+        $cache->clean();
+    }
+}

--- a/src/seeds.php
+++ b/src/seeds.php
@@ -17,6 +17,11 @@ if (!$job_dao->findBy(['name' => $links_fetcher_job->name])) {
     $links_fetcher_job->performLater();
 }
 
+$cache_cleaner_job = new \flusio\jobs\scheduled\CacheCleaner();
+if (!$job_dao->findBy(['name' => $cache_cleaner_job->name])) {
+    $cache_cleaner_job->performLater();
+}
+
 if ($environment === 'development') {
     \flusio\models\Topic::findOrCreateBy(['label' => _('Business')]);
     \flusio\models\Topic::findOrCreateBy(['label' => _('Climate')]);

--- a/tests/jobs/scheduled/CacheCleanerTest.php
+++ b/tests/jobs/scheduled/CacheCleanerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace flusio\jobs\scheduled;
+
+use flusio\models;
+
+class CacheCleanerTest extends \PHPUnit\Framework\TestCase
+{
+    use \tests\FakerHelper;
+    use \Minz\Tests\FactoriesHelper;
+    use \Minz\Tests\InitializerHelper;
+    use \Minz\Tests\TimeHelper;
+
+    public function testQueue()
+    {
+        $cache_cleaner_job = new CacheCleaner();
+
+        $this->assertSame('default', $cache_cleaner_job->queue);
+    }
+
+    public function testSchedule()
+    {
+        $now = $this->fake('dateTime');
+        $this->freeze($now);
+
+        $cache_cleaner_job = new CacheCleaner();
+
+        $expected_perform_at = \Minz\Time::relative('tomorrow 1:00');
+        $this->assertSame(
+            $expected_perform_at->getTimestamp(),
+            $cache_cleaner_job->perform_at->getTimestamp()
+        );
+        $this->assertSame('+1 day', $cache_cleaner_job->frequency);
+    }
+
+    public function testPerform()
+    {
+        $cache_path = \Minz\Configuration::$application['cache_path'];
+        $filepath = $cache_path . '/foo';
+        $validity_interval = 7 * 24 * 60 * 60;
+        $modification_time = time() - $validity_interval;
+        touch($filepath, $modification_time);
+        $cache_cleaner_job = new CacheCleaner();
+
+        $this->assertTrue(file_exists($filepath));
+
+        $cache_cleaner_job->perform();
+
+        $this->assertFalse(file_exists($filepath));
+    }
+
+    public function testPerformKeepsFilesWithinValidityInterval()
+    {
+        $cache_path = \Minz\Configuration::$application['cache_path'];
+        $filepath = $cache_path . '/foo';
+        $validity_interval = 7 * 24 * 60 * 60;
+        $modification_time = time() - $validity_interval + 1;
+        touch($filepath, $modification_time);
+        $cache_cleaner_job = new CacheCleaner();
+
+        $this->assertTrue(file_exists($filepath));
+
+        $cache_cleaner_job->perform();
+
+        $this->assertTrue(file_exists($filepath));
+    }
+}

--- a/tests/lib/SpiderBits/CacheTest.php
+++ b/tests/lib/SpiderBits/CacheTest.php
@@ -109,4 +109,34 @@ class CacheTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame('7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069', $hash);
     }
+
+    public function testClean()
+    {
+        $cache = new Cache(self::$cache_path);
+        $filepath = self::$cache_path . '/foo';
+        $validity_interval = 7 * 24 * 60 * 60;
+        $modification_time = time() - $validity_interval;
+        touch($filepath, $modification_time);
+
+        $this->assertTrue(file_exists($filepath));
+
+        $cache->clean($validity_interval);
+
+        $this->assertFalse(file_exists($filepath));
+    }
+
+    public function testCleanKeepsFilesWithinValidityInterval()
+    {
+        $cache = new Cache(self::$cache_path);
+        $filepath = self::$cache_path . '/foo';
+        $validity_interval = 7 * 24 * 60 * 60;
+        $modification_time = time() - $validity_interval + 1;
+        touch($filepath, $modification_time);
+
+        $this->assertTrue(file_exists($filepath));
+
+        $cache->clean($validity_interval);
+
+        $this->assertTrue(file_exists($filepath));
+    }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a `clean()` method to the SpiderBits Cache class
- Add a scheduled job (every day at 1AM) to clean the cache

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] new tests are written
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
