### PR TITLE
fix: Handle avatar upload with no files

### DIFF
--- a/src/controllers/my/Avatar.php
+++ b/src/controllers/my/Avatar.php
@@ -43,6 +43,11 @@ class Avatar
         }
 
         $uploaded_file = $request->param('avatar');
+        if (!isset($uploaded_file['error'])) {
+            utils\Flash::set('error', _('The file is required.'));
+            return Response::redirect('profile');
+        }
+
         $error_status = $uploaded_file['error'];
         if (
             $error_status === UPLOAD_ERR_INI_SIZE ||

--- a/tests/controllers/my/AvatarTest.php
+++ b/tests/controllers/my/AvatarTest.php
@@ -145,6 +145,22 @@ class AvatarTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($user->avatar_filename);
     }
 
+    public function testUpdateFailsIfFileIsMissing()
+    {
+        $user = $this->login([
+            'avatar_filename' => null,
+        ]);
+
+        $response = $this->appRun('post', '/my/profile/avatar', [
+            'csrf' => $user->csrf,
+        ]);
+
+        $this->assertResponse($response, 302, '/my/profile');
+        $this->assertFlash('error', 'The file is required.');
+        $user = auth\CurrentUser::reload();
+        $this->assertNull($user->avatar_filename);
+    }
+
     public function testUpdateFailsIfWrongFileType()
     {
         // we copy an existing file as a tmp file to simulate an image upload

--- a/tests/models/dao/JobTest.php
+++ b/tests/models/dao/JobTest.php
@@ -130,7 +130,7 @@ class JobTest extends \PHPUnit\Framework\TestCase
     {
         $now = $this->fake('dateTime');
         $this->freeze($now);
-        $minutes_from_now = $this->fake('randomNumber');
+        $minutes_from_now = $this->fake('numberBetween', 1, 9000);
         $number_attempts = $this->fake('numberBetween', 0, 25);
         $job_dao = new Job();
         $job_id = $this->create('job', [


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a test during upload to check a file has been uploaded

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] new tests are written
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
