### PR TITLE
fix: Fix order in feeds for existing links

### DIFF
--- a/src/models/dao/Link.php
+++ b/src/models/dao/Link.php
@@ -306,6 +306,36 @@ class Link extends \Minz\DatabaseModel
     }
 
     /**
+     * Return the list of ids that needs to be synced (i.e. feed_published_at
+     * is null)
+     *
+     * The ids are set as values AND keys of the returned array.
+     *
+     * @param string $user_id
+     *
+     * @return array
+     */
+    public function listIdsToFeedSync($user_id)
+    {
+        $sql = <<<SQL
+            SELECT id FROM links
+            WHERE user_id = :user_id
+            AND feed_published_at IS NULL
+        SQL;
+
+        $statement = $this->prepare($sql);
+        $statement->execute([
+            ':user_id' => $user_id,
+        ]);
+
+        $ids = [];
+        foreach ($statement->fetchAll() as $row) {
+            $ids[$row['id']] = $row['id'];
+        }
+        return $ids;
+    }
+
+    /**
      * Return a list of links to fetch (fetched_at = null)
      *
      * @param integer $number

--- a/tests/jobs/scheduled/FeedsSyncTest.php
+++ b/tests/jobs/scheduled/FeedsSyncTest.php
@@ -145,4 +145,57 @@ class FeedsSyncTest extends \PHPUnit\Framework\TestCase
         $links_number = count($collection->links());
         $this->assertSame(0, $links_number);
     }
+
+    public function testPerformUpdatesLinkFeedInfo()
+    {
+        $support_user = models\User::supportUser();
+        $feed_url = 'https://flus.fr/carnet/feeds/all.atom.xml';
+        $collection_id = $this->create('collection', [
+            'type' => 'feed',
+            'user_id' => $support_user->id,
+            'feed_url' => $feed_url,
+            'feed_fetched_at' => \Minz\Time::ago(2, 'hours')->format(\Minz\Model::DATETIME_FORMAT),
+        ]);
+        $link_url = 'https://flus.fr/carnet/nouveautes-mars-2021.html';
+        $link_entry_id = 'urn:uuid:027e66f5-8137-5040-919d-6377c478ae9d';
+        $link_published = '2021-03-30T09:26:00+00:00';
+        $link_id = $this->create('link', [
+            'url' => $link_url,
+            'user_id' => $support_user->id,
+            'feed_entry_id' => null,
+            'feed_published_at' => null,
+        ]);
+        $hash = \SpiderBits\Cache::hash($feed_url);
+        $raw_response = <<<XML
+        HTTP/2 200 OK
+        Content-Type: application/xml
+
+        <?xml version='1.0' encoding='UTF-8'?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>carnet de flus</title>
+            <link href="https://flus.fr/carnet/feeds/all.atom.xml" rel="self" type="application/atom+xml" />
+            <link href="https://flus.fr/carnet/" rel="alternate" type="text/html" />
+            <id>urn:uuid:4c04fe8e-c966-5b7e-af89-74d092a6ccb0</id>
+            <updated>2021-03-30T11:26:00+02:00</updated>
+            <entry>
+                <title>Les nouveautés de mars 2021</title>
+                <id>{$link_entry_id}</id>
+                <author><name>Marien</name></author>
+                <link href="{$link_url}" rel="alternate" type="text/html" />
+                <published>{$link_published}</published>
+                <updated>2021-03-30T11:26:00+02:00</updated>
+                <content type="html"></content>
+            </entry>
+        </feed>
+        XML;
+        $cache = new \SpiderBits\Cache(\Minz\Configuration::$application['cache_path']);
+        $cache->save($hash, $raw_response);
+        $feeds_sync_job = new FeedsSync();
+
+        $feeds_sync_job->perform();
+
+        $link = models\Link::find($link_id);
+        $this->assertSame($link_entry_id, $link->feed_entry_id);
+        $this->assertSame($link_published, $link->feed_published_at->format(\DateTimeInterface::ATOM));
+    }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Update `link.feed_published_at` during feed sync for existing links without `feed_published_at`

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] new tests are written
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
