### PR TITLE
Tec/refresh links in error

### DIFF
--- a/src/migrations/Migration202104300001AddFetchedCountToLinks.php
+++ b/src/migrations/Migration202104300001AddFetchedCountToLinks.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace flusio\migrations;
+
+class Migration202104300001AddFetchedCountToLinks
+{
+    public function migrate()
+    {
+        $database = \Minz\Database::get();
+
+        $database->exec(<<<'SQL'
+            ALTER TABLE links
+            ADD COLUMN fetched_count INTEGER NOT NULL DEFAULT 0;
+
+            UPDATE links SET fetched_count = 1
+            WHERE fetched_at IS NOT NULL;
+        SQL);
+
+        return true;
+    }
+
+    public function rollback()
+    {
+        $database = \Minz\Database::get();
+
+        $database->exec(<<<'SQL'
+            ALTER TABLE links
+            DROP COLUMN fetched_count;
+        SQL);
+
+        return true;
+    }
+}

--- a/src/migrations/Migration202104300002SetEmptyStringFetchedErrorToNull.php
+++ b/src/migrations/Migration202104300002SetEmptyStringFetchedErrorToNull.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace flusio\migrations;
+
+class Migration202104300002SetEmptyStringFetchedErrorToNull
+{
+    public function migrate()
+    {
+        $database = \Minz\Database::get();
+
+        $database->exec(<<<'SQL'
+            UPDATE links SET fetched_error = null
+            WHERE fetched_error = '';
+
+            UPDATE collections SET feed_fetched_error = null
+            WHERE feed_fetched_error = '';
+        SQL);
+
+        return true;
+    }
+
+    public function rollback()
+    {
+        // Do nothing on purpose
+        return true;
+    }
+}

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -62,6 +62,10 @@ class Link extends \Minz\Model
             'type' => 'string',
         ],
 
+        'fetched_count' => [
+            'type' => 'integer',
+        ],
+
         'user_id' => [
             'type' => 'string',
             'required' => true,
@@ -115,6 +119,7 @@ class Link extends \Minz\Model
             'user_id' => $user_id,
             'reading_time' => 0,
             'fetched_code' => 0,
+            'fetched_count' => 0,
         ]);
     }
 
@@ -136,6 +141,7 @@ class Link extends \Minz\Model
             'reading_time' => $news_link->reading_time,
             'fetched_at' => \Minz\Time::now(),
             'fetched_code' => 200,
+            'fetched_count' => 1,
             'user_id' => $user_id,
         ]);
     }
@@ -158,8 +164,9 @@ class Link extends \Minz\Model
             'image_filename' => $link->image_filename,
             'is_hidden' => false,
             'reading_time' => $link->reading_time,
-            'fetched_at' => \Minz\Time::now(),
-            'fetched_code' => 200,
+            'fetched_at' => $link->fetched_at,
+            'fetched_code' => $link->fetched_code,
+            'fetched_count' => $link->fetched_count,
             'user_id' => $user_id,
         ]);
     }

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -112,6 +112,7 @@ CREATE TABLE links (
     fetched_at TIMESTAMPTZ,
     fetched_code INTEGER NOT NULL DEFAULT 0,
     fetched_error TEXT,
+    fetched_count INTEGER NOT NULL DEFAULT 0,
     user_id TEXT REFERENCES users ON DELETE CASCADE ON UPDATE CASCADE,
 
     feed_entry_id TEXT,

--- a/src/services/FeedFetcher.php
+++ b/src/services/FeedFetcher.php
@@ -47,7 +47,7 @@ class FeedFetcher
 
         $collection->feed_fetched_at = \Minz\Time::now();
         $collection->feed_fetched_code = $info['status'];
-        $collection->feed_fetched_error = '';
+        $collection->feed_fetched_error = null;
         if (isset($info['error'])) {
             $collection->feed_fetched_error = $info['error'];
             $collection->save();

--- a/src/services/LinkFetcher.php
+++ b/src/services/LinkFetcher.php
@@ -51,6 +51,7 @@ class LinkFetcher
         $link->fetched_at = \Minz\Time::now();
         $link->fetched_code = $info['status'];
         $link->fetched_error = '';
+        $link->fetched_count = $link->fetched_count + 1;
         if (isset($info['error'])) {
             $link->fetched_error = $info['error'];
         }

--- a/src/services/LinkFetcher.php
+++ b/src/services/LinkFetcher.php
@@ -50,7 +50,7 @@ class LinkFetcher
 
         $link->fetched_at = \Minz\Time::now();
         $link->fetched_code = $info['status'];
-        $link->fetched_error = '';
+        $link->fetched_error = null;
         $link->fetched_count = $link->fetched_count + 1;
         if (isset($info['error'])) {
             $link->fetched_error = $info['error'];

--- a/tests/jobs/scheduled/LinksFetcherTest.php
+++ b/tests/jobs/scheduled/LinksFetcherTest.php
@@ -48,6 +48,8 @@ class LinksFetcherTest extends \PHPUnit\Framework\TestCase
         $link_id = $this->create('link', [
             'url' => 'https://github.com/flusio/flusio',
             'title' => 'https://github.com/flusio/flusio',
+            'fetched_code' => 0,
+            'fetched_count' => 0,
         ]);
         $links_fetcher_job = new LinksFetcher();
 
@@ -56,6 +58,7 @@ class LinksFetcherTest extends \PHPUnit\Framework\TestCase
         $link = models\Link::find($link_id);
         $this->assertSame('flusio/flusio', $link->title);
         $this->assertSame(200, $link->fetched_code);
+        $this->assertSame(1, $link->fetched_count);
     }
 
     public function testPerformLogsFetch()

--- a/tests/jobs/scheduled/LinksFetcherTest.php
+++ b/tests/jobs/scheduled/LinksFetcherTest.php
@@ -48,6 +48,7 @@ class LinksFetcherTest extends \PHPUnit\Framework\TestCase
         $link_id = $this->create('link', [
             'url' => 'https://github.com/flusio/flusio',
             'title' => 'https://github.com/flusio/flusio',
+            'fetched_at' => null,
             'fetched_code' => 0,
             'fetched_count' => 0,
         ]);
@@ -57,6 +58,7 @@ class LinksFetcherTest extends \PHPUnit\Framework\TestCase
 
         $link = models\Link::find($link_id);
         $this->assertSame('flusio/flusio', $link->title);
+        $this->assertNotNull($link->fetched_at);
         $this->assertSame(200, $link->fetched_code);
         $this->assertSame(1, $link->fetched_count);
     }
@@ -66,6 +68,7 @@ class LinksFetcherTest extends \PHPUnit\Framework\TestCase
         $link_id = $this->create('link', [
             'url' => 'https://github.com/flusio/flusio',
             'title' => 'https://github.com/flusio/flusio',
+            'fetched_at' => null,
         ]);
         $links_fetcher_job = new LinksFetcher();
 
@@ -85,6 +88,7 @@ class LinksFetcherTest extends \PHPUnit\Framework\TestCase
         $link_id = $this->create('link', [
             'url' => $url,
             'title' => $url,
+            'fetched_at' => null,
         ]);
         $links_fetcher_job = new LinksFetcher();
 
@@ -101,6 +105,7 @@ class LinksFetcherTest extends \PHPUnit\Framework\TestCase
         $link_id = $this->create('link', [
             'url' => $url,
             'title' => $url,
+            'fetched_at' => null,
         ]);
         $links_fetcher_job = new LinksFetcher();
         $expected_title = $this->fake('sentence');
@@ -142,6 +147,7 @@ class LinksFetcherTest extends \PHPUnit\Framework\TestCase
         $link_id = $this->create('link', [
             'url' => $url,
             'title' => $url,
+            'fetched_at' => null,
         ]);
         $links_fetcher_job = new LinksFetcher();
 
@@ -151,5 +157,88 @@ class LinksFetcherTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($url, $link->title);
         $this->assertSame(0, $link->fetched_code);
         $this->assertNull($link->fetched_at);
+    }
+
+    public function testPerformFetchesLinksInError()
+    {
+        $now = $this->fake('dateTime');
+        $this->freeze($now);
+        $fetched_count = $this->fake('numberBetween', 1, 25);
+        $interval_to_wait = 5 + pow($fetched_count, 4);
+        $seconds = $this->fake('numberBetween', $interval_to_wait + 1, $interval_to_wait + 9000);
+        $fetched_at = \Minz\Time::ago($seconds, 'seconds');
+        $link_id = $this->create('link', [
+            'url' => 'https://github.com/flusio/flusio',
+            'title' => 'https://github.com/flusio/flusio',
+            'fetched_at' => $fetched_at->format(\Minz\Model::DATETIME_FORMAT),
+            'fetched_code' => 404,
+            'fetched_error' => 'not found',
+            'fetched_count' => $fetched_count,
+        ]);
+        $links_fetcher_job = new LinksFetcher();
+
+        $links_fetcher_job->perform();
+
+        $link = models\Link::find($link_id);
+        $this->assertSame('flusio/flusio', $link->title);
+        $this->assertNotSame($fetched_at->getTimestamp(), $link->fetched_at->getTimestamp());
+        $this->assertSame(200, $link->fetched_code);
+        $this->assertNull($link->fetched_error);
+        $this->assertSame($fetched_count + 1, $link->fetched_count);
+    }
+
+    public function testPerformDoesNotFetchLinksInErrorIfFetchedCountIsGreaterThan25()
+    {
+        $now = $this->fake('dateTime');
+        $this->freeze($now);
+        $fetched_count = $this->fake('numberBetween', 26, 42);
+        $interval_to_wait = 5 + pow($fetched_count, 4);
+        $seconds = $this->fake('numberBetween', $interval_to_wait + 1, $interval_to_wait + 9000);
+        $fetched_at = \Minz\Time::ago($seconds, 'seconds');
+        $link_id = $this->create('link', [
+            'url' => 'https://github.com/flusio/flusio',
+            'title' => 'https://github.com/flusio/flusio',
+            'fetched_at' => $fetched_at->format(\Minz\Model::DATETIME_FORMAT),
+            'fetched_code' => 404,
+            'fetched_error' => 'not found',
+            'fetched_count' => $fetched_count,
+        ]);
+        $links_fetcher_job = new LinksFetcher();
+
+        $links_fetcher_job->perform();
+
+        $link = models\Link::find($link_id);
+        $this->assertSame('https://github.com/flusio/flusio', $link->title);
+        $this->assertSame($fetched_at->getTimestamp(), $link->fetched_at->getTimestamp());
+        $this->assertSame(404, $link->fetched_code);
+        $this->assertSame($fetched_count, $link->fetched_count);
+    }
+
+    public function testPerformDoesNotFetchLinksInErrorIfFetchedAtIsWithinIntervalToWait()
+    {
+        $now = $this->fake('dateTime');
+        $this->freeze($now);
+        $fetched_count = $this->fake('numberBetween', 1, 25);
+        $seconds = $this->fake('numberBetween', 0, 4 * 60);
+        $interval_to_wait = 5 + pow($fetched_count, 4);
+        $seconds = $this->fake('numberBetween', 0, $interval_to_wait);
+        $fetched_at = \Minz\Time::ago($seconds, 'seconds');
+        $link_id = $this->create('link', [
+            'url' => 'https://github.com/flusio/flusio',
+            'title' => 'https://github.com/flusio/flusio',
+            'fetched_at' => $fetched_at->format(\Minz\Model::DATETIME_FORMAT),
+            'fetched_code' => 404,
+            'fetched_error' => 'not found',
+            'fetched_count' => $fetched_count,
+        ]);
+        $links_fetcher_job = new LinksFetcher();
+
+        $links_fetcher_job->perform();
+
+        $link = models\Link::find($link_id);
+        $this->assertSame('https://github.com/flusio/flusio', $link->title);
+        $this->assertSame($fetched_at->getTimestamp(), $link->fetched_at->getTimestamp());
+        $this->assertSame(404, $link->fetched_code);
+        $this->assertSame($fetched_count, $link->fetched_count);
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a fetched_count property to Link
- Force null value for fetched_error when there are no errors
- Return links in error in `listToFetch()`, for a certain time (~4,5 days)

Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] new tests are written
- [x] French locale is synchronized N/A
- [x] commit messages are clear
- [x] documentation is updated (including migration notes)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and/or precise `(N/A)` next to it._
