### PR TITLE
fix: Handle correctly empty responses with SpiderBits

### DIFF
--- a/lib/SpiderBits/src/Response.php
+++ b/lib/SpiderBits/src/Response.php
@@ -38,7 +38,7 @@ class Response
             $body = '';
         } else {
             $headers = $matches['headers'];
-            $body = $matches['body'];
+            $body = $matches['body'] ?? '';
         }
 
         preg_match('/^HTTP\/\d+(\.\d+)?\s+(?P<status>\d{3}).*$/m', $headers, $matches);

--- a/tests/lib/SpiderBits/ResponseTest.php
+++ b/tests/lib/SpiderBits/ResponseTest.php
@@ -22,6 +22,21 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
 
     public function testFromTextWithNoContent()
     {
+        $text = <<<TEXT
+        HTTP/2 204 No content\r
+        Content-Type: text/plain\r
+        \r
+        TEXT;
+
+        $response = Response::fromText($text);
+
+        $this->assertSame(204, $response->status);
+        $this->assertSame('text/plain', $response->headers['content-type']);
+        $this->assertSame('', $response->data);
+    }
+
+    public function testFromTextWithNoContentAndNoFinalEmptyLine()
+    {
         // Even 204 response should contain a final empty line. We just try to
         // be more robust than the norm.
         $text = <<<TEXT


### PR DESCRIPTION
Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated
- [x] French locale is synchronized N/A
- [x] documentation is updated (including comments, commit messages, migration notes, …)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `(N/A)` next to it._
