### PR TITLE
misc: Make selected_computed_props optional

### DIFF
--- a/src/controllers/collections/Read.php
+++ b/src/controllers/collections/Read.php
@@ -88,7 +88,7 @@ class Read
         $collection = models\Collection::find($collection_id);
         $links = [];
         if (auth\CollectionsAccess::canUpdateRead($user, $collection)) {
-            $links = $collection->links([]);
+            $links = $collection->links();
         } elseif ($user->isFollowing($collection->id)) {
             // This loop is not efficient since the collection may contain a
             // lot of links. If it becomes an issue, it could be fixed by
@@ -149,7 +149,7 @@ class Read
         $collection = models\Collection::find($collection_id);
         $links = [];
         if (auth\CollectionsAccess::canUpdateRead($user, $collection)) {
-            $links = $collection->links([]);
+            $links = $collection->links();
         } elseif ($user->isFollowing($collection->id)) {
             foreach ($collection->links([], ['hidden' => false]) as $link) {
                 $new_link = $user->obtainLink($link);
@@ -204,7 +204,7 @@ class Read
         $collection = models\Collection::find($collection_id);
         $links = [];
         if (auth\CollectionsAccess::canUpdateRead($user, $collection)) {
-            $links = $collection->links([]);
+            $links = $collection->links();
         } elseif ($user->isFollowing($collection->id)) {
             foreach ($collection->links([], ['hidden' => false]) as $link) {
                 $new_link = $user->obtainLink($link);

--- a/src/controllers/my/Info.php
+++ b/src/controllers/my/Info.php
@@ -29,7 +29,7 @@ class Info
         }
 
         $bookmarks = $user->bookmarks();
-        $links = $bookmarks->links([]);
+        $links = $bookmarks->links();
         $json_output = json_encode([
             'csrf' => $user->csrf,
             'bookmarks_id' => $bookmarks->id,

--- a/src/models/Collection.php
+++ b/src/models/Collection.php
@@ -248,7 +248,7 @@ class Collection extends \Minz\Model
      *
      * @return \flusio\models\Link[]
      */
-    public function links($selected_computed_props, $options = [])
+    public function links($selected_computed_props = [], $options = [])
     {
         return Link::daoToList(
             'listComputedByCollectionId',

--- a/tests/cli/FeedsTest.php
+++ b/tests/cli/FeedsTest.php
@@ -178,7 +178,7 @@ class FeedsTest extends \PHPUnit\Framework\TestCase
         $this->assertResponse($response, 200, "Feed {$collection_id} ({$feed_url}) has been synchronized.");
         $collection = models\Collection::find($collection_id);
         $this->assertSame('Carnet de Flus', $collection->name);
-        $links_number = count($collection->links([]));
+        $links_number = count($collection->links());
         $this->assertGreaterThan(0, $links_number);
     }
 
@@ -240,7 +240,7 @@ class FeedsTest extends \PHPUnit\Framework\TestCase
 
         $collection = models\Collection::find($collection_id);
         $this->assertSame($expected_name, $collection->name);
-        $link = $collection->links([])[0];
+        $link = $collection->links()[0];
         $this->assertSame($expected_title, $link->title);
     }
 
@@ -286,7 +286,7 @@ class FeedsTest extends \PHPUnit\Framework\TestCase
 
         $collection = models\Collection::find($collection_id);
         $this->assertNotSame($not_expected_name, $collection->name);
-        $link = $collection->links([])[0];
+        $link = $collection->links()[0];
         $this->assertNotSame($not_expected_title, $link->title);
     }
 

--- a/tests/jobs/scheduled/FeedsSyncTest.php
+++ b/tests/jobs/scheduled/FeedsSyncTest.php
@@ -103,7 +103,7 @@ class FeedsSyncTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull($collection->image_fetched_at);
         $this->assertNotNull($collection->image_filename);
         $this->assertNull($collection->locked_at);
-        $links_number = count($collection->links([]));
+        $links_number = count($collection->links());
         $this->assertGreaterThan(0, $links_number);
     }
 
@@ -209,7 +209,7 @@ class FeedsSyncTest extends \PHPUnit\Framework\TestCase
 
         $collection = models\Collection::find($collection_id);
         $this->assertSame($expected_name, $collection->name);
-        $link = $collection->links([])[0];
+        $link = $collection->links()[0];
         $this->assertSame($expected_title, $link->title);
     }
 
@@ -287,7 +287,7 @@ class FeedsSyncTest extends \PHPUnit\Framework\TestCase
 
         $collection = models\Collection::find($collection_id);
         $this->assertSame($expected_name, $collection->name);
-        $links_number = count($collection->links([]));
+        $links_number = count($collection->links());
         $this->assertSame(0, $links_number);
     }
 
@@ -497,7 +497,7 @@ class FeedsSyncTest extends \PHPUnit\Framework\TestCase
         $feeds_sync_job->perform();
 
         $collection = models\Collection::find($collection_id);
-        $this->assertEmpty($collection->links([]));
+        $this->assertEmpty($collection->links());
     }
 
     public function testPerformIgnoresEntriesIfUrlExistsInCollection()
@@ -611,7 +611,7 @@ class FeedsSyncTest extends \PHPUnit\Framework\TestCase
         $feeds_sync_job->perform();
 
         $collection = models\Collection::find($collection_id);
-        $link = $collection->links([])[0];
+        $link = $collection->links()[0];
         $this->assertSame($link->url, $link->feed_entry_id);
     }
 
@@ -725,7 +725,7 @@ class FeedsSyncTest extends \PHPUnit\Framework\TestCase
 
         $collection = models\Collection::find($collection_id);
         $this->assertSame('https://flus.fr/carnet/', $collection->feed_site_url);
-        $link = $collection->links([])[0];
+        $link = $collection->links()[0];
         $this->assertSame('https://flus.fr/carnet/nouveautes-mars-2021.html', $link->url);
     }
 
@@ -878,7 +878,7 @@ class FeedsSyncTest extends \PHPUnit\Framework\TestCase
 
         $collection = models\Collection::find($collection_id);
         $this->assertNotSame($name, $collection->name);
-        $this->assertEmpty($collection->links([]));
+        $this->assertEmpty($collection->links());
     }
 
     public function testPerformFetchesFeedIfLockedAfterAnHour()
@@ -934,7 +934,7 @@ class FeedsSyncTest extends \PHPUnit\Framework\TestCase
 
         $collection = models\Collection::find($collection_id);
         $this->assertSame($expected_name, $collection->name);
-        $link = $collection->links([])[0];
+        $link = $collection->links()[0];
         $this->assertSame($expected_title, $link->title);
     }
 }


### PR DESCRIPTION
Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated
- [x] French locale is synchronized N/A
- [x] documentation is updated (including comments, commit messages, migration notes, …)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `(N/A)` next to it._
