### PR TITLE
imp: Examine responses with no content type

### DIFF
--- a/src/services/LinkFetcher.php
+++ b/src/services/LinkFetcher.php
@@ -219,8 +219,9 @@ class LinkFetcher
             return $info;
         }
 
-        if (!utils\Belt::contains($content_type, 'text/html')) {
-            // We operate on HTML only
+        if ($content_type && !utils\Belt::contains($content_type, 'text/html')) {
+            // We operate on HTML only. If content type is not declared, we
+            // examine data hoping for HTML.
             return $info; // @codeCoverageIgnore
         }
 


### PR DESCRIPTION
Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated
- [x] French locale is synchronized N/A
- [x] documentation is updated (including comments, commit messages, migration notes, …)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `(N/A)` next to it._
