### PR TITLE
fix: Sync newest feeds links when keep_period is set

### DIFF
--- a/src/services/FeedFetcher.php
+++ b/src/services/FeedFetcher.php
@@ -181,7 +181,7 @@ class FeedFetcher
             }
 
             $links_to_collections[] = [
-                'published_at' => $published_at->format(\Minz\Model::DATETIME_FORMAT),
+                'published_at' => $published_at,
                 'link_id' => $link_id,
                 'collection_id' => $collection->id,
             ];
@@ -380,7 +380,7 @@ class FeedFetcher
         if ($feeds_links_keep_period <= 0) {
             // If "keep period" is not set, we create all the links_to_collections
             foreach ($links_to_collections as $link_to_collection) {
-                $to_create[] = $link_to_collection['published_at'];
+                $to_create[] = $link_to_collection['published_at']->format(\Minz\Model::DATETIME_FORMAT);
                 $to_create[] = $link_to_collection['link_id'];
                 $to_create[] = $link_to_collection['collection_id'];
             }
@@ -399,7 +399,7 @@ class FeedFetcher
                 $enough_links = $links_count >= $feeds_links_keep_minimum;
 
                 if ($recent_enough || !$enough_links) {
-                    $to_create[] = $link_to_collection['published_at'];
+                    $to_create[] = $link_to_collection['published_at']->format(\Minz\Model::DATETIME_FORMAT);
                     $to_create[] = $link_to_collection['link_id'];
                     $to_create[] = $link_to_collection['collection_id'];
                     $links_count = $links_count + 1;

--- a/tests/jobs/scheduled/FeedsSyncTest.php
+++ b/tests/jobs/scheduled/FeedsSyncTest.php
@@ -621,6 +621,58 @@ class FeedsSyncTest extends \PHPUnit\Framework\TestCase
         $this->assertEmpty($collection->links());
     }
 
+    public function testPerformTakesEntriesIfRecentEnoughWhenKeepPeriodIsSet()
+    {
+        \Minz\Configuration::$application['feeds_links_keep_period'] = 6;
+        $this->freeze($this->fake('dateTime'));
+        $feed_url = 'https://flus.fr/carnet/feeds/all.atom.xml';
+        $months = $this->fake('numberBetween', 0, 6);
+        $published_at = \Minz\Time::ago($months, 'months');
+        $collection_id = $this->create('collection', [
+            'type' => 'feed',
+            'feed_url' => $feed_url,
+            'feed_fetched_at' => \Minz\Time::ago(2, 'hours')->format(\Minz\Model::DATETIME_FORMAT),
+        ]);
+        $this->create('followed_collection', [
+            'collection_id' => $collection_id,
+        ]);
+        $hash = \SpiderBits\Cache::hash($feed_url);
+        $raw_response = <<<XML
+        HTTP/2 200 OK
+        Content-Type: application/xml
+
+        <?xml version='1.0' encoding='UTF-8'?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>carnet de flus</title>
+            <link href="https://flus.fr/carnet/feeds/all.atom.xml" rel="self" type="application/atom+xml" />
+            <link href="https://flus.fr/carnet/" rel="alternate" type="text/html" />
+            <id>urn:uuid:4c04fe8e-c966-5b7e-af89-74d092a6ccb0</id>
+            <updated>2021-03-30T11:26:00+02:00</updated>
+            <entry>
+                <title>Les nouveautés de mars 2021</title>
+                <id>urn:uuid:027e66f5-8137-5040-919d-6377c478ae9d</id>
+                <author><name>Marien</name></author>
+                <link href="https://flus.fr/carnet/nouveautes-mars-2021.html" rel="alternate" type="text/html"/>
+                <published>{$published_at->format(DATE_ATOM)}</published>
+                <updated>2021-03-30T11:26:00+02:00</updated>
+                <content type="html"></content>
+            </entry>
+        </feed>
+        XML;
+        $cache = new \SpiderBits\Cache(\Minz\Configuration::$application['cache_path']);
+        $cache->save($hash, $raw_response);
+        $feeds_sync_job = new FeedsSync();
+
+        $feeds_sync_job->perform();
+
+        \Minz\Configuration::$application['feeds_links_keep_period'] = 0;
+
+        $collection = models\Collection::find($collection_id);
+        $links = $collection->links();
+        $this->assertSame(1, count($links));
+        $this->assertSame('Les nouveautés de mars 2021', $links[0]->title);
+    }
+
     public function testPerformTakesEntriesIfOlderThanKeepPeriodUntilMinimum()
     {
         \Minz\Configuration::$application['feeds_links_keep_period'] = 6;


### PR DESCRIPTION
Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated
- [x] French locale is synchronized N/A
- [x] documentation is updated (including comments, commit messages, migration notes, …)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
