### PR TITLE
tec: Handle feeds declaring a wrong encoding

### DIFF
--- a/tests/lib/SpiderBits/feeds/FeedTest.php
+++ b/tests/lib/SpiderBits/feeds/FeedTest.php
@@ -238,6 +238,28 @@ class FeedTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('4a022608d595e9000d1f1be22a0a6a0763ad853d2417b1c8ea0ea12bd047bdcd', $feed->hash());
     }
 
+    public function testFromTextRecoversFromWrongEncoding()
+    {
+        // Create a XML string declaring encoding UTF-8
+        $xml = <<<XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <rss version="2.0">
+                <channel>
+                    <title>My feed with an àccent</title>
+                    <link>https://example.com</link>
+                </channel>
+            </rss>
+            XML;
+        // … but its real encoding is ISO-8859-1!
+        $xml = mb_convert_encoding($xml, 'ISO-8859-1', 'UTF-8');
+
+        $feed = Feed::fromText($xml);
+
+        $this->assertSame('My feed with an ?ccent', $feed->title);
+        $this->assertSame('https://example.com', $feed->link);
+        $this->assertSame('0ca0efc2ed6d8bfab90dbd3f42a473465c505b3d13b4da5975b0deed52c4b231', $feed->hash());
+    }
+
     public function testFromTextFailsWithEmptyString()
     {
         $this->expectException(\DomainException::class);


### PR DESCRIPTION
Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens N/A
- [x] accessibility has been tested N/A
- [x] tests are updated
- [x] French locale is synchronized N/A
- [x] documentation is updated (including comments, commit messages, migration notes, …)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
