### PR TITLE
fix: Handle Response::utf8Data with unsupported encodings

### DIFF
--- a/lib/SpiderBits/src/Response.php
+++ b/lib/SpiderBits/src/Response.php
@@ -138,8 +138,11 @@ class Response
      */
     public function utf8Data(): string
     {
-        $encoding = $this->encoding();
-        return mb_convert_encoding($this->data, 'utf-8', $encoding);
+        try {
+            return mb_convert_encoding($this->data, 'utf-8', $this->encoding());
+        } catch (\ValueError $exception) {
+            return mb_convert_encoding($this->data, 'utf-8', 'utf-8');
+        }
     }
 
     /**


### PR DESCRIPTION
Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated
- [x] French locale is synchronized
- [x] documentation is updated (including comments, commit messages, migration notes, …)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
