### PR TITLE
fix: Ignore invalid URLs when synchronising feeds

### DIFF
--- a/lib/SpiderBits/src/Url.php
+++ b/lib/SpiderBits/src/Url.php
@@ -378,4 +378,29 @@ class Url
         }
         return implode('&', $built_parameters);
     }
+
+    /**
+     * Return true if the given URL is valid, false otherwise.
+     *
+     * @param string[] $accepted_schemes
+     */
+    public static function isValid(string $url, array $accepted_schemes = ['http', 'https']): bool
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            return false;
+        }
+
+        $url_components = parse_url($url);
+
+        if (
+            !$url_components ||
+            !isset($url_components['scheme']) ||
+            !isset($url_components['host'])
+        ) {
+            return false;
+        }
+
+        $url_scheme = strtolower($url_components['scheme']);
+        return in_array($url_scheme, $accepted_schemes);
+    }
 }

--- a/src/services/FeedFetcher.php
+++ b/src/services/FeedFetcher.php
@@ -131,6 +131,10 @@ class FeedFetcher
             $url = \SpiderBits\Url::absolutize($entry->link, $feed_url);
             $url = \SpiderBits\Url::sanitize($url);
 
+            if (!\SpiderBits\Url::isValid($url)) {
+                continue;
+            }
+
             if (isset($link_ids_by_urls[$url])) {
                 // The URL is already associated to the collection, we have
                 // nothing more to do.

--- a/tests/lib/SpiderBits/UrlTest.php
+++ b/tests/lib/SpiderBits/UrlTest.php
@@ -48,6 +48,51 @@ class UrlTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($expected_query, $query);
     }
 
+    public function testIsValid(): void
+    {
+        $url = 'https://example.com';
+
+        $result = Url::isValid($url);
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsValidFailsWithAnEmptyString(): void
+    {
+        $url = '';
+
+        $result = Url::isValid($url);
+
+        $this->assertFalse($result);
+    }
+
+    public function testIsValidFailsWithAnInvalidUrl(): void
+    {
+        $url = 'https://example com';
+
+        $result = Url::isValid($url);
+
+        $this->assertFalse($result);
+    }
+
+    public function testIsValidFailsWithAMissingScheme(): void
+    {
+        $url = 'example.com';
+
+        $result = Url::isValid($url);
+
+        $this->assertFalse($result);
+    }
+
+    public function testIsValidFailsWithAnInvalidScheme(): void
+    {
+        $url = 'http://example.com';
+
+        $result = Url::isValid($url, ['https']);
+
+        $this->assertFalse($result);
+    }
+
     /**
      * @return array<array{string, string, string}>
      */


### PR DESCRIPTION
Pull request checklist:

- [x] code is manually tested
- [x] interface works on both mobiles and big screens
- [x] accessibility has been tested
- [x] tests are updated
- [x] French locale is synchronized
- [x] documentation is updated (including comments, commit messages, migration notes, …)

_If you think one of the item isn’t applicable to the PR, please check it
anyway and precise `N/A` next to it._
